### PR TITLE
feat(lsp): add Tier 1 and Tier 2 LSP features — workspace/symbol, semanticTokens, completion, signatureHelp, rename, inlayHints, selectionRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 
 ### Fixed
 
+- **aiken-lsp**: Fix `path_to_uri` using manual string concatenation — replaced with `Url::from_file_path()` to produce properly encoded URIs.
+- **aiken-lsp**: Handle background compilation thread panics gracefully — preserve `files_changed_since_compile` so the next save retries, and show an error message instead of silently losing diagnostics.
+- **aiken-lsp**: Fix `publish_stored_diagnostics` always being called after compile (even on thread panic) so the client always receives diagnostic updates.
+- **aiken-lsp**: Fix `parse_document` reading from disk during code actions — now uses in-editor content from the `edited` map when available, so quickfixes apply to the correct positions.
+- **aiken-lsp**: Add 300ms debounced compile on `DidChangeTextDocument` — diagnostics now update live while typing, matching Python/TypeScript LSP behavior.
+- **aiken-lsp**: Add `EditedFileGuard` — temporarily writes unsaved edits to disk before compilation and restores originals after (even on panic), so diagnostics reflect the current editor content.
 - **uplc**: Fixed conversion/discrepancy from large negative bigint when using `Data::integer`; mostly impacting value reification and tracing of large negative integers. Fixes [#1241](https://github.com/aiken-lang/aiken/issues/1241). @KtorZ
 - **uplc**: Make evaluation failures language-dependent; thus allowing V1 & V2 evaluations to return non-unit results. @michaeljfazio, @KtorZ
 - **aiken-lang**: Improve/fix formatter on assignments, in particular multiline ones. @KtorZ

--- a/crates/aiken-lang/src/tipo/error.rs
+++ b/crates/aiken-lang/src/tipo/error.rs
@@ -1925,15 +1925,15 @@ pub enum Warning {
 impl ExtraData for Warning {
     fn extra_data(&self) -> Option<String> {
         match self {
+            Warning::UnusedVariable { name, .. } => Some(name.clone()),
+            Warning::DiscardedLetAssignment { name, .. } => Some(name.clone()),
+            Warning::Todo { tipo, .. } => Some(tipo.to_pretty(0)),
+            Warning::SingleWhenClause { sample, .. } => Some(format_suggestion(sample)),
             Warning::AllFieldsRecordUpdate { .. }
             | Warning::ImplicitlyDiscardedResult { .. }
             | Warning::NoFieldsRecordUpdate { .. }
             | Warning::SingleConstructorExpect { .. }
-            | Warning::SingleWhenClause { .. }
-            | Warning::Todo { .. }
             | Warning::UnusedConstructor { .. }
-            | Warning::UnusedVariable { .. }
-            | Warning::DiscardedLetAssignment { .. }
             | Warning::ValidatorInLibraryModule { .. }
             | Warning::CompactTraceLabelIsNotstring { .. }
             | Warning::UseWhenInstead { .. } => None,

--- a/crates/aiken-lsp/src/completion.rs
+++ b/crates/aiken-lsp/src/completion.rs
@@ -1,0 +1,432 @@
+use crate::server::Server;
+use aiken_lang::{
+    ast::{Definition, Located, Use},
+    tipo::pretty::Printer,
+    tipo::{TypeInfo, ValueConstructor, ValueConstructorVariant},
+};
+use aiken_project::module::CheckedModule;
+use itertools::Itertools;
+use lsp_types::{
+    CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+};
+use std::collections::HashMap;
+
+impl Server {
+    pub fn completion(&self, params: lsp_types::CompletionParams) -> Option<Vec<CompletionItem>> {
+        let found = self
+            .node_at_position(&params.text_document_position)
+            .map(|(_, found)| found);
+
+        let module = self.module_for_uri(&params.text_document_position.text_document.uri);
+        let type_info = module.map(|m| &m.ast.type_info);
+        let compiler = self.compiler.as_ref();
+
+        match found {
+            None => {
+                let compiler = compiler?;
+                Some(completion_for_import(
+                    &compiler.modules,
+                    compiler.project.importable_modules(),
+                    &[],
+                ))
+            }
+            Some(Located::Definition(Definition::Use(Use { module, .. }))) => {
+                let compiler = compiler?;
+                Some(completion_for_import(
+                    &compiler.modules,
+                    compiler.project.importable_modules(),
+                    module,
+                ))
+            }
+            Some(Located::Expression(_expression)) => {
+                let (compiler, type_info) = match (compiler, type_info) {
+                    (Some(c), Some(t)) => (c, t),
+                    _ => return None,
+                };
+                completion_for_expression(type_info, compiler)
+            }
+            Some(Located::Pattern(_pattern, tipo)) => {
+                let type_info = type_info?;
+                completion_for_pattern(type_info, &tipo)
+            }
+            Some(Located::Annotation(_annotation)) => {
+                let type_info = type_info?;
+                completion_for_annotation(type_info)
+            }
+            Some(Located::Argument(_arg_name, _tipo)) => {
+                let type_info = type_info?;
+                completion_for_argument(type_info)
+            }
+            Some(Located::Definition(_)) => None,
+        }
+    }
+}
+
+/// Generate import path completions from available modules
+fn completion_for_import(
+    local_modules: &HashMap<String, CheckedModule>,
+    dependency_modules: Vec<String>,
+    module: &[String],
+) -> Vec<CompletionItem> {
+    let project_modules = local_modules.keys().cloned();
+    let modules = dependency_modules
+        .into_iter()
+        .chain(project_modules)
+        .sorted()
+        .filter(|m| m.starts_with(&module.join("/")))
+        .map(|label| CompletionItem {
+            label,
+            kind: Some(CompletionItemKind::MODULE),
+            documentation: None,
+            ..Default::default()
+        })
+        .collect();
+
+    modules
+}
+
+/// Generate completions for expressions: in-scope values + module names for qualified access
+fn completion_for_expression(
+    type_info: &TypeInfo,
+    compiler: &crate::server::lsp_project::LspProject,
+) -> Option<Vec<CompletionItem>> {
+    let mut items = Vec::new();
+
+    // In-scope values: functions, constants, local variables
+    for (name, constructor) in &type_info.values {
+        // Skip local variables (they clutter autocomplete — user already knows them)
+        if constructor.variant.is_local_variable() {
+            continue;
+        }
+
+        // Skip ordinal-named arguments like "1st_arg", "2nd_arg" etc.
+        if is_ordinal_argument_name(name) {
+            continue;
+        }
+
+        items.push(value_to_completion_item(name, constructor));
+    }
+
+    // Add module names for qualified access (e.g. `module.`)
+    for module_name in compiler.project.importable_modules() {
+        // Don't suggest the current module itself
+        if module_name == type_info.name {
+            continue;
+        }
+        items.push(CompletionItem {
+            label: module_name,
+            kind: Some(CompletionItemKind::MODULE),
+            documentation: None,
+            ..Default::default()
+        });
+    }
+
+    // Sort: in-scope values first (sorted by label), then modules
+    // But we'll just sort everything by label for simplicity
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+
+    Some(items)
+}
+
+/// Generate completions for patterns: find constructors matching the pattern type
+fn completion_for_pattern(
+    type_info: &TypeInfo,
+    tipo: &std::rc::Rc<aiken_lang::tipo::Type>,
+) -> Option<Vec<CompletionItem>> {
+    let mut items = Vec::new();
+
+    // Get the type name from the type to look up its constructors
+    // Use Printer to get a readable type name
+    let type_name = Printer::new().pretty_print(tipo.as_ref(), 0);
+
+    // Look up constructors for this type name
+    if let Some(constructor_names) = type_info.types_constructors.get(&type_name) {
+        for name in constructor_names {
+            if let Some(constructor) = type_info.values.get(name) {
+                items.push(value_to_completion_item(name, constructor));
+            }
+        }
+    }
+
+    // If no constructors found by name, also try to find any constructor whose
+    // return type matches. Fall back to listing all Record variants in scope.
+    if items.is_empty() {
+        for (name, constructor) in &type_info.values {
+            if matches!(constructor.variant, ValueConstructorVariant::Record { .. }) {
+                items.push(value_to_completion_item(name, constructor));
+            }
+        }
+    }
+
+    Some(items)
+}
+
+/// Generate completions for type annotations: list all types in scope
+fn completion_for_annotation(type_info: &TypeInfo) -> Option<Vec<CompletionItem>> {
+    let mut items = Vec::new();
+
+    for (name, type_constructor) in &type_info.types {
+        let type_str = Printer::new().pretty_print(&type_constructor.tipo, 0);
+
+        items.push(CompletionItem {
+            label: name.clone(),
+            kind: Some(CompletionItemKind::CLASS),
+            detail: None,
+            documentation: Some(Documentation::MarkupContent(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: format!("```aiken\n{}\n```", type_str),
+            })),
+            ..Default::default()
+        });
+    }
+
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+    Some(items)
+}
+
+/// Generate completions for arguments: suggest labeled argument names from function field maps
+fn completion_for_argument(type_info: &TypeInfo) -> Option<Vec<CompletionItem>> {
+    let mut items = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    // Collect labeled argument suggestions from all ModuleFn values in scope
+    for constructor in type_info.values.values() {
+        if let ValueConstructorVariant::ModuleFn {
+            field_map: Some(ref field_map),
+            ..
+        } = constructor.variant
+        {
+            for (label, (_index, _span)) in &field_map.fields {
+                if seen.insert(label.clone()) {
+                    items.push(CompletionItem {
+                        label: format!("{label}:"),
+                        kind: Some(CompletionItemKind::PROPERTY),
+                        detail: Some(format!("labeled argument `{label}`")),
+                        documentation: None,
+                        insert_text: Some(format!("{label}: ${{1}}")),
+                        insert_text_format: Some(InsertTextFormat::SNIPPET),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+    }
+
+    // Also suggest labeled fields from Record constructors
+    for constructor in type_info.values.values() {
+        if let ValueConstructorVariant::Record {
+            field_map: Some(ref field_map),
+            ..
+        } = constructor.variant
+        {
+            for (label, (_index, _span)) in &field_map.fields {
+                if seen.insert(label.clone()) {
+                    items.push(CompletionItem {
+                        label: format!("{label}:"),
+                        kind: Some(CompletionItemKind::PROPERTY),
+                        detail: Some(format!("record field `{label}`")),
+                        documentation: None,
+                        insert_text: Some(format!("{label}: ${{1}}")),
+                        insert_text_format: Some(InsertTextFormat::SNIPPET),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+    }
+
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+    Some(items)
+}
+
+/// Convert a ValueConstructor to an LSP CompletionItem
+fn value_to_completion_item(name: &str, constructor: &ValueConstructor) -> CompletionItem {
+    let (kind, detail) = match &constructor.variant {
+        ValueConstructorVariant::LocalVariable { .. } => (CompletionItemKind::VARIABLE, None),
+        ValueConstructorVariant::ModuleFn {
+            arity,
+            field_map,
+            name: fn_name,
+            ..
+        } => {
+            let sig = format_function_signature(name, *arity, field_map.as_ref());
+            let detail = if fn_name != name {
+                Some(format!("fn {sig}"))
+            } else {
+                Some(sig)
+            };
+            (CompletionItemKind::FUNCTION, detail)
+        }
+        ValueConstructorVariant::ModuleConstant {
+            name: const_name, ..
+        } => {
+            let detail = if const_name != name {
+                Some(format!("const {name}"))
+            } else {
+                Some("const".to_string())
+            };
+            (CompletionItemKind::CONSTANT, detail)
+        }
+        ValueConstructorVariant::Record {
+            arity,
+            field_map,
+            constructors_count,
+            ..
+        } => {
+            let detail_text = if *constructors_count > 1 {
+                format!(
+                    "{} (variant of {constructors_count})",
+                    format_constructor_signature(name, *arity, field_map.as_ref())
+                )
+            } else {
+                format_constructor_signature(name, *arity, field_map.as_ref())
+            };
+            (CompletionItemKind::CONSTRUCTOR, Some(detail_text))
+        }
+    };
+
+    let type_str = Printer::new().pretty_print(&constructor.tipo, 0);
+
+    let insert_text = format_insert_text(name, &constructor.variant);
+
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(kind),
+        detail,
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!("```aiken\n{}\n```", type_str),
+        })),
+        insert_text: Some(insert_text),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        ..Default::default()
+    }
+}
+
+/// Format a function signature string for display
+fn format_function_signature(
+    name: &str,
+    arity: usize,
+    field_map: Option<&aiken_lang::tipo::fields::FieldMap>,
+) -> String {
+    let args = match field_map {
+        Some(fm) if !fm.fields.is_empty() => format_labeled_args(arity, fm),
+        _ => (0..arity).map(|_| "_".to_string()).join(", "),
+    };
+
+    format!("{name}({args})")
+}
+
+fn format_labeled_args(arity: usize, field_map: &aiken_lang::tipo::fields::FieldMap) -> String {
+    let mut args: Vec<String> = Vec::with_capacity(arity);
+    let mut entries: Vec<(&String, &(usize, aiken_lang::ast::Span))> =
+        field_map.fields.iter().collect();
+    entries.sort_by_key(|(_, (idx, _))| *idx);
+
+    let mut filled = 0;
+    for (label, (idx, _)) in &entries {
+        while filled < *idx {
+            args.push("_".to_string());
+            filled += 1;
+        }
+        args.push(label.to_string());
+        filled += 1;
+    }
+    while filled < arity {
+        args.push("_".to_string());
+        filled += 1;
+    }
+    args.join(", ")
+}
+
+/// Format a constructor signature string for display
+fn format_constructor_signature(
+    name: &str,
+    arity: usize,
+    field_map: Option<&aiken_lang::tipo::fields::FieldMap>,
+) -> String {
+    if arity == 0 {
+        return name.to_string();
+    }
+
+    let args = match field_map {
+        Some(fm) if !fm.fields.is_empty() => format_labeled_args(arity, fm),
+        _ => (0..arity).map(|_| "_".to_string()).join(", "),
+    };
+
+    format!("{name}({args})")
+}
+
+/// Generate snippet-based insert text for functions and constructors with arguments
+fn format_insert_text(name: &str, variant: &ValueConstructorVariant) -> String {
+    match variant {
+        ValueConstructorVariant::ModuleFn {
+            arity,
+            field_map: Some(field_map),
+            ..
+        } if *arity > 0 && !field_map.fields.is_empty() => {
+            let mut positional = field_map.fields.iter().collect::<Vec<_>>();
+            positional.sort_by_key(|(_, (idx, _))| *idx);
+
+            let mut parts = Vec::with_capacity(*arity);
+            let mut filled = 0;
+            for (label, (idx, _)) in &positional {
+                while filled < *idx {
+                    parts.push(format!("${{{}:_}}", filled + 1));
+                    filled += 1;
+                }
+                parts.push(format!("{label}: ${{{}:_}}", filled + 1));
+                filled += 1;
+            }
+            while filled < *arity {
+                parts.push(format!("${{{}:_}}", filled + 1));
+                filled += 1;
+            }
+            format!("{}({})", name, parts.join(", "))
+        }
+        ValueConstructorVariant::ModuleFn { arity, .. } if *arity > 0 => {
+            let parts: Vec<String> = (1..=*arity).map(|i| format!("${{{i}:_}}")).collect();
+            format!("{}({})", name, parts.join(", "))
+        }
+        ValueConstructorVariant::Record {
+            arity,
+            field_map: Some(field_map),
+            ..
+        } if *arity > 0 && !field_map.fields.is_empty() => {
+            let mut positional = field_map.fields.iter().collect::<Vec<_>>();
+            positional.sort_by_key(|(_, (idx, _))| *idx);
+
+            let mut parts = Vec::with_capacity(*arity);
+            let mut filled = 0;
+            for (label, (idx, _)) in &positional {
+                while filled < *idx {
+                    parts.push(format!("${{{}:_}}", filled + 1));
+                    filled += 1;
+                }
+                parts.push(format!("{label}: ${{{}:_}}", filled + 1));
+                filled += 1;
+            }
+            while filled < *arity {
+                parts.push(format!("${{{}:_}}", filled + 1));
+                filled += 1;
+            }
+            format!("{}({})", name, parts.join(", "))
+        }
+        ValueConstructorVariant::Record { arity, .. } if *arity > 0 => {
+            let parts: Vec<String> = (1..=*arity).map(|i| format!("${{{i}:_}}")).collect();
+            format!("{}({})", name, parts.join(", "))
+        }
+        _ => name.to_string(),
+    }
+}
+
+/// Returns true if the name looks like an auto-generated ordinal argument name (e.g. "1st_arg")
+fn is_ordinal_argument_name(name: &str) -> bool {
+    // Pattern: starts with digit, contains "st_arg" or "nd_arg" or "rd_arg" or "th_arg"
+    if let Some(first_char) = name.chars().next() {
+        if first_char.is_ascii_digit() {
+            return name.ends_with("_arg");
+        }
+    }
+    false
+}

--- a/crates/aiken-lsp/src/completion.rs
+++ b/crates/aiken-lsp/src/completion.rs
@@ -69,7 +69,7 @@ fn completion_for_import(
     module: &[String],
 ) -> Vec<CompletionItem> {
     let project_modules = local_modules.keys().cloned();
-    let modules = dependency_modules
+    dependency_modules
         .into_iter()
         .chain(project_modules)
         .sorted()
@@ -80,9 +80,7 @@ fn completion_for_import(
             documentation: None,
             ..Default::default()
         })
-        .collect();
-
-    modules
+        .collect()
 }
 
 /// Generate completions for expressions: in-scope values + module names for qualified access
@@ -423,10 +421,10 @@ fn format_insert_text(name: &str, variant: &ValueConstructorVariant) -> String {
 /// Returns true if the name looks like an auto-generated ordinal argument name (e.g. "1st_arg")
 fn is_ordinal_argument_name(name: &str) -> bool {
     // Pattern: starts with digit, contains "st_arg" or "nd_arg" or "rd_arg" or "th_arg"
-    if let Some(first_char) = name.chars().next() {
-        if first_char.is_ascii_digit() {
-            return name.ends_with("_arg");
-        }
+    if let Some(first_char) = name.chars().next()
+        && first_char.is_ascii_digit()
+    {
+        return name.ends_with("_arg");
     }
     false
 }

--- a/crates/aiken-lsp/src/edits.rs
+++ b/crates/aiken-lsp/src/edits.rs
@@ -4,7 +4,7 @@ use aiken_lang::{
     line_numbers::LineNumbers,
 };
 use itertools::Itertools;
-use std::fs;
+use std::{collections::HashMap, fs};
 
 /// A freshly parsed module alongside its line numbers.
 pub struct ParsedDocument {
@@ -20,13 +20,20 @@ pub enum AnnotatedEdit {
 
 /// Parse the target document as an 'UntypedModule' alongside its line numbers. This is useful in
 /// case we need to manipulate the AST for a quickfix.
-pub fn parse_document(document: &lsp_types::TextDocumentIdentifier) -> Option<ParsedDocument> {
+/// If the document has unsaved edits (in the `edited` map), those are used instead of disk content.
+pub fn parse_document(
+    document: &lsp_types::TextDocumentIdentifier,
+    edited: &HashMap<String, String>,
+) -> Option<ParsedDocument> {
     let file_path = document
         .uri
         .to_file_path()
         .expect("invalid text document uri?");
 
-    let source_code = fs::read_to_string(file_path).ok()?;
+    let source_code = match edited.get(file_path.to_str()?) {
+        Some(content) => content.clone(),
+        None => fs::read_to_string(&file_path).ok()?,
+    };
 
     let line_numbers = LineNumbers::new(&source_code);
 

--- a/crates/aiken-lsp/src/error.rs
+++ b/crates/aiken-lsp/src/error.rs
@@ -29,4 +29,7 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(code(aiken::lsp::send))]
     PathToUri(#[from] url::ParseError),
+    #[error("Failed to convert path to URI: {0}")]
+    #[diagnostic(code(aiken::lsp::uri))]
+    UriError(String),
 }

--- a/crates/aiken-lsp/src/lib.rs
+++ b/crates/aiken-lsp/src/lib.rs
@@ -5,11 +5,14 @@ use lsp_server::Connection;
 use std::env;
 
 mod cast;
+mod completion;
 mod edits;
 pub mod error;
 mod quickfix;
 mod rename;
+mod semantic_tokens;
 pub mod server;
+mod signature_help;
 pub mod utils;
 
 #[allow(clippy::result_large_err)]
@@ -54,20 +57,21 @@ pub fn start() -> Result<(), Error> {
 
 fn capabilities() -> lsp_types::ServerCapabilities {
     lsp_types::ServerCapabilities {
-        // THIS IS STILL WEIRD, ONLY ENABLE IF DEVELOPING
-        // completion_provider: Some(lsp_types::CompletionOptions {
-        //     resolve_provider: None,
-        //     trigger_characters: Some(vec![".".into(), " ".into()]),
-        //     all_commit_characters: None,
-        //     work_done_progress_options: lsp_types::WorkDoneProgressOptions {
-        //         work_done_progress: None,
-        //     },
-        // }),
+        completion_provider: Some(lsp_types::CompletionOptions {
+            resolve_provider: None,
+            trigger_characters: Some(vec![".".into(), " ".into()]),
+            all_commit_characters: None,
+            completion_item: None,
+            work_done_progress_options: lsp_types::WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        }),
         code_action_provider: Some(lsp_types::CodeActionProviderCapability::Simple(true)),
         document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
         definition_provider: Some(lsp_types::OneOf::Left(true)),
         document_symbol_provider: Some(lsp_types::OneOf::Left(true)),
         references_provider: Some(lsp_types::OneOf::Left(true)),
+        selection_range_provider: Some(lsp_types::SelectionRangeProviderCapability::Simple(true)),
         rename_provider: Some(lsp_types::OneOf::Right(lsp_types::RenameOptions {
             prepare_provider: Some(true),
             work_done_progress_options: lsp_types::WorkDoneProgressOptions {
@@ -76,6 +80,26 @@ fn capabilities() -> lsp_types::ServerCapabilities {
         })),
         hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
         inlay_hint_provider: Some(lsp_types::OneOf::Left(true)),
+        semantic_tokens_provider: Some(
+            lsp_types::SemanticTokensServerCapabilities::SemanticTokensOptions(
+                lsp_types::SemanticTokensOptions {
+                    legend: semantic_tokens::semantic_tokens_legend(),
+                    range: Some(true),
+                    full: Some(lsp_types::SemanticTokensFullOptions::Bool(true)),
+                    work_done_progress_options: lsp_types::WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
+                },
+            ),
+        ),
+        workspace_symbol_provider: Some(lsp_types::OneOf::Left(true)),
+        signature_help_provider: Some(lsp_types::SignatureHelpOptions {
+            trigger_characters: Some(vec!["(".into(), ",".into()]),
+            retrigger_characters: Some(vec![",".into()]),
+            work_done_progress_options: lsp_types::WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        }),
         text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Options(
             lsp_types::TextDocumentSyncOptions {
                 open_close: None,

--- a/crates/aiken-lsp/src/lib.rs
+++ b/crates/aiken-lsp/src/lib.rs
@@ -80,8 +80,8 @@ fn capabilities() -> lsp_types::ServerCapabilities {
             lsp_types::TextDocumentSyncOptions {
                 open_close: None,
                 change: Some(lsp_types::TextDocumentSyncKind::FULL),
-                will_save: None,
-                will_save_wait_until: None,
+                will_save: Some(true),
+                will_save_wait_until: Some(true),
                 save: Some(lsp_types::TextDocumentSyncSaveOptions::SaveOptions(
                     lsp_types::SaveOptions {
                         include_text: Some(false),

--- a/crates/aiken-lsp/src/lib.rs
+++ b/crates/aiken-lsp/src/lib.rs
@@ -8,6 +8,7 @@ mod cast;
 mod edits;
 pub mod error;
 mod quickfix;
+mod rename;
 pub mod server;
 pub mod utils;
 
@@ -67,7 +68,14 @@ fn capabilities() -> lsp_types::ServerCapabilities {
         definition_provider: Some(lsp_types::OneOf::Left(true)),
         document_symbol_provider: Some(lsp_types::OneOf::Left(true)),
         references_provider: Some(lsp_types::OneOf::Left(true)),
+        rename_provider: Some(lsp_types::OneOf::Right(lsp_types::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: lsp_types::WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        })),
         hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
+        inlay_hint_provider: Some(lsp_types::OneOf::Left(true)),
         text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Options(
             lsp_types::TextDocumentSyncOptions {
                 open_close: None,

--- a/crates/aiken-lsp/src/lib.rs
+++ b/crates/aiken-lsp/src/lib.rs
@@ -66,7 +66,15 @@ fn capabilities() -> lsp_types::ServerCapabilities {
                 work_done_progress: None,
             },
         }),
-        code_action_provider: Some(lsp_types::CodeActionProviderCapability::Simple(true)),
+        code_action_provider: Some(lsp_types::CodeActionProviderCapability::Options(
+            lsp_types::CodeActionOptions {
+                code_action_kinds: Some(vec![lsp_types::CodeActionKind::QUICKFIX]),
+                resolve_provider: Some(true),
+                work_done_progress_options: lsp_types::WorkDoneProgressOptions {
+                    work_done_progress: None,
+                },
+            },
+        )),
         document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
         definition_provider: Some(lsp_types::OneOf::Left(true)),
         document_symbol_provider: Some(lsp_types::OneOf::Left(true)),

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -19,6 +19,14 @@ const UNUSED_PRIVATE_FUNCTION: &str = "aiken::check::unused::function";
 const UNUSED_PRIVATE_CONSTANT: &str = "aiken::check::unused::constant";
 const UNUSED_PRIVATE_TYPE: &str = "aiken::check::unused::type";
 const PRIVATE_TYPE_LEAK: &str = "aiken::check::private_leak";
+const UNUSED_VARIABLE: &str = "aiken::check::unused::variable";
+const DISCARDED_LET_ASSIGNMENT: &str = "aiken::check::unused::discarded_let_assignment";
+const TODO: &str = "aiken::check::todo";
+const IF_IS_ON_NON_DATA: &str = "aiken::check::if_is_on_non_data";
+const SINGLE_WHEN_CLAUSE: &str = "aiken::check::single_when_clause";
+const IMPLICIT_DISCARD: &str = "aiken::check::implicit_discard";
+const ALL_FIELDS_RECORD_UPDATE: &str = "aiken::check::record_update::all_fields";
+const NO_FIELDS_RECORD_UPDATE: &str = "aiken::check::record_update::no_fields";
 
 /// Errors for which we can provide quickfixes
 #[allow(clippy::enum_variant_names)]
@@ -33,6 +41,14 @@ pub enum Quickfix {
     UnexpectedTypeHole(lsp_types::Diagnostic),
     UnusedPrivate(lsp_types::Diagnostic),
     PrivateLeak(lsp_types::Diagnostic),
+    UnusedVariable(lsp_types::Diagnostic),
+    DiscardedLetAssignment(lsp_types::Diagnostic),
+    Todo(lsp_types::Diagnostic),
+    IfIsOnNonData(lsp_types::Diagnostic),
+    SingleWhenClause(lsp_types::Diagnostic),
+    ImplicitDiscard(lsp_types::Diagnostic),
+    AllFieldsRecordUpdate(lsp_types::Diagnostic),
+    NoFieldsRecordUpdate(lsp_types::Diagnostic),
 }
 
 fn match_code(
@@ -100,6 +116,38 @@ pub fn assert(diagnostic: lsp_types::Diagnostic) -> Option<Quickfix> {
         return Some(Quickfix::PrivateLeak(diagnostic));
     }
 
+    if match_code(&diagnostic, Severity::WARNING, UNUSED_VARIABLE) {
+        return Some(Quickfix::UnusedVariable(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, DISCARDED_LET_ASSIGNMENT) {
+        return Some(Quickfix::DiscardedLetAssignment(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, TODO) {
+        return Some(Quickfix::Todo(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, IF_IS_ON_NON_DATA) {
+        return Some(Quickfix::IfIsOnNonData(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, SINGLE_WHEN_CLAUSE) {
+        return Some(Quickfix::SingleWhenClause(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, IMPLICIT_DISCARD) {
+        return Some(Quickfix::ImplicitDiscard(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, ALL_FIELDS_RECORD_UPDATE) {
+        return Some(Quickfix::AllFieldsRecordUpdate(diagnostic));
+    }
+
+    if match_code(&diagnostic, Severity::WARNING, NO_FIELDS_RECORD_UPDATE) {
+        return Some(Quickfix::NoFieldsRecordUpdate(diagnostic));
+    }
+
     None
 }
 
@@ -111,88 +159,179 @@ pub fn quickfix(
 ) -> Vec<lsp_types::CodeAction> {
     let mut actions = Vec::new();
 
-    if let Some(ref parsed_document) = edits::parse_document(text_document, edited) {
-        match quickfix {
-            Quickfix::UnknownIdentifier(diagnostic) => {
+    // Try to parse document - only needed for import-based actions
+    let parsed_document = edits::parse_document(text_document, edited);
+
+    match quickfix {
+        // --- Actions that NEED parsed_document for AST manipulation ---
+        Quickfix::UnknownIdentifier(diagnostic) => {
+            if let Some(ref parsed) = parsed_document {
                 each_as_distinct_action(
                     &mut actions,
                     text_document,
                     diagnostic,
                     unknown_identifier(
                         compiler,
-                        parsed_document,
+                        parsed,
                         &diagnostic.range,
                         diagnostic.data.as_ref(),
                     ),
                 );
             }
-            Quickfix::UnknownModule(diagnostic) => each_as_distinct_action(
-                &mut actions,
-                text_document,
-                diagnostic,
-                unknown_module(compiler, parsed_document, diagnostic.data.as_ref()),
-            ),
-            Quickfix::UnknownConstructor(diagnostic) => each_as_distinct_action(
-                &mut actions,
-                text_document,
-                diagnostic,
-                unknown_constructor(
-                    compiler,
-                    parsed_document,
-                    &diagnostic.range,
-                    diagnostic.data.as_ref(),
-                ),
-            ),
-            Quickfix::UnusedImports(diagnostics) => as_single_action(
-                &mut actions,
-                text_document,
-                diagnostics.to_owned(),
-                "Remove redundant imports",
-                unused_imports(
-                    parsed_document,
-                    diagnostics
-                        .iter()
-                        .map(|diagnostic| diagnostic.data.as_ref())
-                        .collect(),
-                ),
-            ),
-            Quickfix::Utf8ByteArrayIsValidHexString(diagnostic) => each_as_distinct_action(
+        }
+        Quickfix::UnknownModule(diagnostic) => {
+            if let Some(ref parsed) = parsed_document {
+                each_as_distinct_action(
+                    &mut actions,
+                    text_document,
+                    diagnostic,
+                    unknown_module(compiler, parsed, diagnostic.data.as_ref()),
+                );
+            }
+        }
+        Quickfix::UnknownConstructor(diagnostic) => {
+            if let Some(ref parsed) = parsed_document {
+                each_as_distinct_action(
+                    &mut actions,
+                    text_document,
+                    diagnostic,
+                    unknown_constructor(
+                        compiler,
+                        parsed,
+                        &diagnostic.range,
+                        diagnostic.data.as_ref(),
+                    ),
+                );
+            }
+        }
+        Quickfix::UnusedImports(diagnostics) => {
+            if let Some(ref parsed) = parsed_document {
+                as_single_action(
+                    &mut actions,
+                    text_document,
+                    diagnostics.to_owned(),
+                    "Remove redundant imports",
+                    unused_imports(
+                        parsed,
+                        diagnostics
+                            .iter()
+                            .map(|diagnostic| diagnostic.data.as_ref())
+                            .collect(),
+                    ),
+                );
+            }
+        }
+        Quickfix::PrivateLeak(diagnostic) => {
+            if let Some(ref parsed) = parsed_document {
+                each_as_distinct_action(
+                    &mut actions,
+                    text_document,
+                    diagnostic,
+                    make_type_public(parsed, diagnostic),
+                );
+            }
+        }
+        // --- Actions that DON'T need parsed_document ---
+        Quickfix::Utf8ByteArrayIsValidHexString(diagnostic) => {
+            each_as_distinct_action(
                 &mut actions,
                 text_document,
                 diagnostic,
                 utf8_byte_array_is_hex_string(diagnostic),
-            ),
-            Quickfix::UseLet(diagnostic) => each_as_distinct_action(
-                &mut actions,
-                text_document,
-                diagnostic,
-                use_let(diagnostic),
-            ),
-            Quickfix::UnusedRecordFields(diagnostic) => each_as_distinct_action(
+            );
+        }
+        Quickfix::UseLet(diagnostic) => {
+            each_as_distinct_action(&mut actions, text_document, diagnostic, use_let(diagnostic));
+        }
+        Quickfix::UnusedRecordFields(diagnostic) => {
+            each_as_distinct_action(
                 &mut actions,
                 text_document,
                 diagnostic,
                 unused_record_fields(diagnostic),
-            ),
-            Quickfix::UnexpectedTypeHole(diagnostic) => each_as_distinct_action(
+            );
+        }
+        Quickfix::UnexpectedTypeHole(diagnostic) => {
+            each_as_distinct_action(
                 &mut actions,
                 text_document,
                 diagnostic,
                 fill_type_hole(diagnostic),
-            ),
-            Quickfix::UnusedPrivate(diagnostic) => each_as_distinct_action(
+            );
+        }
+        Quickfix::UnusedPrivate(diagnostic) => {
+            each_as_distinct_action(
                 &mut actions,
                 text_document,
                 diagnostic,
                 make_value_public(diagnostic),
-            ),
-            Quickfix::PrivateLeak(diagnostic) => each_as_distinct_action(
+            );
+        }
+        // --- NEW simple text-replacement actions ---
+        Quickfix::UnusedVariable(diagnostic) => {
+            each_as_distinct_action(
                 &mut actions,
                 text_document,
                 diagnostic,
-                make_type_public(parsed_document, diagnostic),
-            ),
-        };
+                prefix_with_underscore(diagnostic),
+            );
+        }
+        Quickfix::DiscardedLetAssignment(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                prefix_with_underscore(diagnostic),
+            );
+        }
+        Quickfix::Todo(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                fill_todo(diagnostic),
+            );
+        }
+        Quickfix::IfIsOnNonData(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                replace_if_with_when(diagnostic),
+            );
+        }
+        Quickfix::SingleWhenClause(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                replace_when_with_let(diagnostic),
+            );
+        }
+        Quickfix::ImplicitDiscard(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                add_discard_binding(diagnostic),
+            );
+        }
+        Quickfix::AllFieldsRecordUpdate(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                remove_redundant_record_update(diagnostic),
+            );
+        }
+        Quickfix::NoFieldsRecordUpdate(diagnostic) => {
+            each_as_distinct_action(
+                &mut actions,
+                text_document,
+                diagnostic,
+                remove_redundant_record_update(diagnostic),
+            );
+        }
     }
 
     actions
@@ -204,7 +343,7 @@ fn each_as_distinct_action(
     diagnostic: &lsp_types::Diagnostic,
     edits: Vec<AnnotatedEdit>,
 ) {
-    for edit in edits.into_iter() {
+    for (i, edit) in edits.into_iter().enumerate() {
         let mut changes = HashMap::new();
 
         let title = match edit {
@@ -222,7 +361,7 @@ fn each_as_distinct_action(
             title,
             kind: Some(lsp_types::CodeActionKind::QUICKFIX),
             diagnostics: Some(vec![diagnostic.clone()]),
-            is_preferred: Some(true),
+            is_preferred: if i == 0 { Some(true) } else { None },
             disabled: None,
             data: None,
             command: None,
@@ -486,7 +625,7 @@ fn make_type_public(
                 let start = parsed_document.position(
                     start
                         .parse::<usize>()
-                        .expect("malformed unused_imports argument: not a usize"),
+                        .expect("malformed private_leak argument: not a usize"),
                 );
 
                 edits.push(AnnotatedEdit::SimpleEdit(
@@ -498,10 +637,91 @@ fn make_type_public(
                 ));
             }
             _ => {
-                panic!("malformed unused_imports arguments: not a 2-tuple");
+                panic!("malformed private_leak arguments: not a 2-tuple");
             }
         }
     }
 
     edits
+}
+
+fn prefix_with_underscore(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    vec![AnnotatedEdit::SimpleEdit(
+        "Prefix with '_'".to_string(),
+        lsp_types::TextEdit {
+            range: lsp_types::Range {
+                start: diagnostic.range.start,
+                end: diagnostic.range.start,
+            },
+            new_text: "_".to_string(),
+        },
+    )]
+}
+
+fn fill_todo(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    let mut edits = Vec::new();
+    if let Some(serde_json::Value::String(inferred_type)) = diagnostic.data.as_ref() {
+        edits.push(AnnotatedEdit::SimpleEdit(
+            format!("Replace 'todo' with '{inferred_type}'"),
+            lsp_types::TextEdit {
+                range: diagnostic.range,
+                new_text: inferred_type.clone(),
+            },
+        ));
+    }
+    edits.push(AnnotatedEdit::SimpleEdit(
+        "Replace 'todo' with '_'".to_string(),
+        lsp_types::TextEdit {
+            range: diagnostic.range,
+            new_text: "_".to_string(),
+        },
+    ));
+    edits
+}
+
+fn replace_if_with_when(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    vec![AnnotatedEdit::SimpleEdit(
+        "Replace 'if' with 'when'".to_string(),
+        lsp_types::TextEdit {
+            range: diagnostic.range,
+            new_text: "when".to_string(),
+        },
+    )]
+}
+
+fn replace_when_with_let(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    let mut edits = Vec::new();
+    if let Some(serde_json::Value::String(let_binding)) = diagnostic.data.as_ref() {
+        edits.push(AnnotatedEdit::SimpleEdit(
+            "Replace 'when' with 'let'".to_string(),
+            lsp_types::TextEdit {
+                range: diagnostic.range,
+                new_text: let_binding.clone(),
+            },
+        ));
+    }
+    edits
+}
+
+fn add_discard_binding(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    vec![AnnotatedEdit::SimpleEdit(
+        "Add explicit discard binding".to_string(),
+        lsp_types::TextEdit {
+            range: lsp_types::Range {
+                start: diagnostic.range.start,
+                end: diagnostic.range.start,
+            },
+            new_text: "let _ = ".to_string(),
+        },
+    )]
+}
+
+fn remove_redundant_record_update(diagnostic: &lsp_types::Diagnostic) -> Vec<AnnotatedEdit> {
+    vec![AnnotatedEdit::SimpleEdit(
+        "Remove redundant record update".to_string(),
+        lsp_types::TextEdit {
+            range: diagnostic.range,
+            new_text: String::new(),
+        },
+    )]
 }

--- a/crates/aiken-lsp/src/quickfix.rs
+++ b/crates/aiken-lsp/src/quickfix.rs
@@ -107,10 +107,11 @@ pub fn quickfix(
     compiler: &LspProject,
     text_document: &lsp_types::TextDocumentIdentifier,
     quickfix: &Quickfix,
+    edited: &HashMap<String, String>,
 ) -> Vec<lsp_types::CodeAction> {
     let mut actions = Vec::new();
 
-    if let Some(ref parsed_document) = edits::parse_document(text_document) {
+    if let Some(ref parsed_document) = edits::parse_document(text_document, edited) {
         match quickfix {
             Quickfix::UnknownIdentifier(diagnostic) => {
                 each_as_distinct_action(

--- a/crates/aiken-lsp/src/rename.rs
+++ b/crates/aiken-lsp/src/rename.rs
@@ -1,0 +1,152 @@
+use crate::{server::Server, utils::span_to_lsp_range};
+use aiken_lang::{
+    ast::{Definition, Located, Span, TypedDefinition},
+    line_numbers::LineNumbers,
+};
+use lsp_types::{PrepareRenameResponse, RenameParams, TextEdit, WorkspaceEdit};
+use std::collections::HashMap;
+
+// ── Free helper functions (self-contained, no Server dependency) ──────────
+
+/// Search source text within a span for a name string and return the narrowed Span.
+fn find_identifier_span(source: &str, span: Span, name: &str) -> Option<Span> {
+    let text = &source[span.start..span.end];
+    let offset = text.find(name)?;
+    Some(Span {
+        start: span.start + offset,
+        end: span.start + offset + name.len(),
+    })
+}
+
+/// Extract the name string from a typed definition.
+fn def_name(def: &TypedDefinition) -> Option<&str> {
+    match def {
+        Definition::Fn(f) => Some(&f.name),
+        Definition::DataType(dt) => Some(&dt.name),
+        Definition::TypeAlias(ta) => Some(&ta.alias),
+        Definition::ModuleConstant(c) => Some(&c.name),
+        Definition::Validator(v) => Some(&v.name),
+        Definition::Test(t) => Some(&t.name),
+        Definition::Benchmark(b) => Some(&b.name),
+        Definition::Use(_) => None,
+    }
+}
+
+// ── Server impl ───────────────────────────────────────────────────────────
+
+impl Server {
+    /// Handle `textDocument/prepareRename` — return the range of the identifier
+    /// at the cursor position if renaming is supported for it.
+    pub fn prepare_rename(
+        &self,
+        params: lsp_types::TextDocumentPositionParams,
+    ) -> Option<PrepareRenameResponse> {
+        let compiler = self.compiler.as_ref()?;
+        let module = self.module_for_uri(&params.text_document.uri)?;
+        let line_numbers = LineNumbers::new(&module.code);
+
+        let target = self.find_symbol_at_position(&params.position, module, &line_numbers)?;
+
+        // Block renaming of dependency symbols
+        let own_package = compiler.own_package();
+        if let Some(def_module) = &target.def_module
+            && let Some(def_mod) = compiler.modules.get(def_module)
+            && def_mod.package != *own_package
+        {
+            return None;
+        }
+
+        let byte_index = line_numbers.byte_index(
+            params.position.line as usize,
+            params.position.character as usize,
+        );
+
+        if let Some(node) = module.find_node(byte_index)
+            && let Some(name_span) = identifier_span_for_node(&node, &module.code)
+        {
+            let range = span_to_lsp_range(name_span, &line_numbers);
+            return Some(PrepareRenameResponse::Range(range));
+        }
+
+        None
+    }
+
+    /// Handle `textDocument/rename` — rename a symbol and all its references.
+    pub fn rename(&self, params: RenameParams) -> Option<WorkspaceEdit> {
+        let compiler = self.compiler.as_ref()?;
+        let module = self.module_for_uri(&params.text_document_position.text_document.uri)?;
+        let line_numbers = LineNumbers::new(&module.code);
+
+        let target = self.find_symbol_at_position(
+            &params.text_document_position.position,
+            module,
+            &line_numbers,
+        )?;
+
+        // Block renaming of dependency symbols
+        let own_package = compiler.own_package();
+        if let Some(def_module) = &target.def_module
+            && let Some(def_mod) = compiler.modules.get(def_module)
+            && def_mod.package != *own_package
+        {
+            return None;
+        }
+
+        let mut changes: HashMap<lsp_types::Url, Vec<TextEdit>> = HashMap::new();
+        let new_name = &params.new_name;
+
+        // Collect references from all modules
+        for (module_name, checked_module) in &compiler.modules {
+            if let Some(locations) =
+                self.find_references_in_module(&target, checked_module, module_name)
+            {
+                for location in locations {
+                    changes.entry(location.uri).or_default().push(TextEdit {
+                        range: location.range,
+                        new_text: new_name.clone(),
+                    });
+                }
+            }
+        }
+
+        // Include the definition site (identifier span only)
+        let def_mod_name = target.def_module.as_deref().unwrap_or(&module.name);
+        if let Some(def_mod) = compiler.modules.get(def_mod_name)
+            && let Some(uri) = self.module_name_to_uri(def_mod_name)
+            && let Some(name_span) =
+                find_identifier_span(&def_mod.code, target.def_span, &target.name)
+        {
+            let def_ln = LineNumbers::new(&def_mod.code);
+            let range = span_to_lsp_range(name_span, &def_ln);
+            changes.entry(uri).or_default().push(TextEdit {
+                range,
+                new_text: new_name.clone(),
+            });
+        }
+
+        if changes.is_empty() {
+            return None;
+        }
+
+        Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        })
+    }
+}
+
+// ── Local helpers ──────────────────────────────────────────────────────────
+
+/// Extract the span of the identifier name within a `Located` AST node.
+fn identifier_span_for_node(node: &Located<'_>, source: &str) -> Option<Span> {
+    match node {
+        Located::Definition(def) => {
+            let name = def_name(def)?;
+            find_identifier_span(source, def.location(), name)
+        }
+        Located::Expression(aiken_lang::expr::TypedExpr::Var { name, location, .. }) => {
+            find_identifier_span(source, *location, name)
+        }
+        _ => None,
+    }
+}

--- a/crates/aiken-lsp/src/semantic_tokens.rs
+++ b/crates/aiken-lsp/src/semantic_tokens.rs
@@ -1,0 +1,488 @@
+use aiken_lang::{
+    ast::{Definition, Span, TypedDefinition, TypedPattern},
+    expr::TypedExpr,
+    line_numbers::LineNumbers,
+    parser::extra::ModuleExtra,
+};
+use aiken_project::module::CheckedModule;
+use lsp_types::{SemanticTokenModifier, SemanticTokenType, SemanticTokensLegend};
+
+const FUNCTION: u32 = 0;
+const VARIABLE: u32 = 1;
+const CLASS: u32 = 2;
+const CONSTRUCTOR: u32 = 3;
+const KEYWORD: u32 = 4;
+const STRING: u32 = 5;
+const NUMBER: u32 = 6;
+const COMMENT: u32 = 7;
+const NAMESPACE: u32 = 8;
+const TYPE: u32 = 9;
+const OPERATOR: u32 = 10;
+const ENUM_MEMBER: u32 = 11;
+
+const DECLARATION_BIT: u32 = 1 << 0;
+const DOCUMENTATION_BIT: u32 = 1 << 1;
+const READONLY_BIT: u32 = 1 << 2;
+
+pub fn semantic_tokens_legend() -> SemanticTokensLegend {
+    SemanticTokensLegend {
+        token_types: vec![
+            SemanticTokenType::FUNCTION,
+            SemanticTokenType::VARIABLE,
+            SemanticTokenType::CLASS,
+            SemanticTokenType::new("constructor"),
+            SemanticTokenType::KEYWORD,
+            SemanticTokenType::STRING,
+            SemanticTokenType::NUMBER,
+            SemanticTokenType::COMMENT,
+            SemanticTokenType::NAMESPACE,
+            SemanticTokenType::TYPE,
+            SemanticTokenType::OPERATOR,
+            SemanticTokenType::ENUM_MEMBER,
+        ],
+        token_modifiers: vec![
+            SemanticTokenModifier::DECLARATION,
+            SemanticTokenModifier::DOCUMENTATION,
+            SemanticTokenModifier::READONLY,
+        ],
+    }
+}
+
+pub fn semantic_tokens_full(module: &CheckedModule) -> Vec<u32> {
+    let line_numbers = LineNumbers::new(&module.code);
+    let mut collector = RawCollector::new(&line_numbers);
+
+    collect_doc_comments(&mut collector, &module.extra, &module.code);
+
+    for def in &module.ast.definitions {
+        collector.collect_definition(def);
+    }
+
+    collect_keywords(&mut collector, &module.code, &line_numbers);
+
+    collector
+        .tokens
+        .sort_by(|a, b| a.line.cmp(&b.line).then(a.start_char.cmp(&b.start_char)));
+
+    collector.tokens.retain(|t| t.length > 0);
+
+    encode(collector.tokens)
+}
+
+struct RawToken {
+    line: u32,
+    start_char: u32,
+    length: u32,
+    token_type: u32,
+    token_modifiers: u32,
+}
+
+fn encode(tokens: Vec<RawToken>) -> Vec<u32> {
+    let mut out = Vec::with_capacity(tokens.len() * 5);
+    let mut prev_line: u32 = 0;
+    let mut prev_start: u32 = 0;
+
+    for t in &tokens {
+        let delta_line = t.line.wrapping_sub(prev_line);
+        let delta_start = if delta_line == 0 {
+            t.start_char.wrapping_sub(prev_start)
+        } else {
+            t.start_char
+        };
+
+        out.push(delta_line);
+        out.push(delta_start);
+        out.push(t.length);
+        out.push(t.token_type);
+        out.push(t.token_modifiers);
+
+        prev_line = t.line;
+        prev_start = t.start_char;
+    }
+
+    out
+}
+
+struct RawCollector<'a> {
+    line_numbers: &'a LineNumbers,
+    tokens: Vec<RawToken>,
+}
+
+impl<'a> RawCollector<'a> {
+    fn new(line_numbers: &'a LineNumbers) -> Self {
+        Self {
+            line_numbers,
+            tokens: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, span: Span, token_type: u32, token_modifiers: u32) {
+        let length = span.end.saturating_sub(span.start) as u32;
+        if length == 0 {
+            return;
+        }
+        let start = self
+            .line_numbers
+            .line_and_column_number(span.start)
+            .unwrap();
+        self.tokens.push(RawToken {
+            line: (start.line - 1) as u32,
+            start_char: (start.column - 1) as u32,
+            length,
+            token_type,
+            token_modifiers,
+        });
+    }
+
+    fn collect_definition(&mut self, def: &TypedDefinition) {
+        match def {
+            Definition::Fn(func) => {
+                self.push(func.location, FUNCTION, DECLARATION_BIT);
+                for arg in &func.arguments {
+                    self.collect_arg(arg);
+                }
+                self.collect_expr(&func.body);
+            }
+            Definition::Test(func) | Definition::Benchmark(func) => {
+                self.push(func.location, FUNCTION, DECLARATION_BIT);
+                for arg_via in &func.arguments {
+                    self.collect_arg(&arg_via.arg);
+                }
+                self.collect_expr(&func.body);
+            }
+            Definition::TypeAlias(ta) => {
+                self.push(ta.location, CLASS, DECLARATION_BIT);
+                self.collect_annotation(&ta.annotation);
+            }
+            Definition::DataType(dt) => {
+                self.push(dt.location, CLASS, DECLARATION_BIT);
+                for ctor in &dt.constructors {
+                    self.push(ctor.location, CONSTRUCTOR, DECLARATION_BIT);
+                    for field in &ctor.arguments {
+                        self.collect_annotation(&field.annotation);
+                    }
+                }
+            }
+            Definition::ModuleConstant(mc) => {
+                self.push(mc.location, VARIABLE, READONLY_BIT);
+                if let Some(ann) = &mc.annotation {
+                    self.collect_annotation(ann);
+                }
+                self.collect_expr(&mc.value);
+            }
+            Definition::Validator(v) => {
+                self.push(v.location, CLASS, DECLARATION_BIT);
+                for param in &v.params {
+                    self.collect_arg(param);
+                }
+                for handler in &v.handlers {
+                    self.push(handler.location, FUNCTION, DECLARATION_BIT);
+                    for arg in &handler.arguments {
+                        self.collect_arg(arg);
+                    }
+                    self.collect_expr(&handler.body);
+                }
+                for arg in &v.fallback.arguments {
+                    self.collect_arg(arg);
+                }
+                self.collect_expr(&v.fallback.body);
+            }
+            Definition::Use(u) => {
+                self.push(u.location, NAMESPACE, 0);
+                for imp in &u.unqualified.1 {
+                    self.push(imp.location, FUNCTION, 0);
+                }
+            }
+        }
+    }
+
+    fn collect_arg(&mut self, arg: &aiken_lang::ast::TypedArg) {
+        self.push(arg.arg_name.location(), VARIABLE, DECLARATION_BIT);
+        if let Some(ann) = &arg.annotation {
+            self.collect_annotation(ann);
+        }
+    }
+
+    fn collect_expr(&mut self, expr: &TypedExpr) {
+        match expr {
+            TypedExpr::UInt { location, .. } | TypedExpr::String { location, .. } => {
+                let ty = if matches!(expr, TypedExpr::String { .. }) {
+                    STRING
+                } else {
+                    NUMBER
+                };
+                self.push(*location, ty, 0);
+            }
+            TypedExpr::ByteArray { location, .. } => {
+                self.push(*location, STRING, 0);
+            }
+            TypedExpr::CurvePoint { location, .. } => {
+                self.push(*location, STRING, 0);
+            }
+            TypedExpr::Sequence { expressions, .. } => {
+                for e in expressions {
+                    self.collect_expr(e);
+                }
+            }
+            TypedExpr::Pipeline { expressions, .. } => {
+                for e in expressions.iter() {
+                    self.collect_expr(e);
+                }
+            }
+            TypedExpr::Var { location, .. } => {
+                self.push(*location, FUNCTION, 0);
+            }
+            TypedExpr::Fn { args, body, .. } => {
+                for arg in args {
+                    self.collect_arg(arg);
+                }
+                self.collect_expr(body);
+            }
+            TypedExpr::List { elements, tail, .. } => {
+                for e in elements {
+                    self.collect_expr(e);
+                }
+                if let Some(t) = tail {
+                    self.collect_expr(t);
+                }
+            }
+            TypedExpr::Call { fun, args, .. } => {
+                self.collect_expr(fun);
+                for arg in args {
+                    self.collect_expr(&arg.value);
+                }
+            }
+            TypedExpr::BinOp {
+                location,
+                left,
+                right,
+                ..
+            } => {
+                self.push(*location, OPERATOR, 0);
+                self.collect_expr(left);
+                self.collect_expr(right);
+            }
+            TypedExpr::Assignment { value, pattern, .. } => {
+                self.collect_pattern(pattern, DECLARATION_BIT);
+                self.collect_expr(value);
+            }
+            TypedExpr::Trace { then, text, .. } => {
+                self.collect_expr(then);
+                self.collect_expr(text);
+            }
+            TypedExpr::When {
+                subject, clauses, ..
+            } => {
+                self.collect_expr(subject);
+                for clause in clauses {
+                    self.collect_pattern(&clause.pattern, 0);
+                    self.collect_expr(&clause.then);
+                }
+            }
+            TypedExpr::If {
+                branches,
+                final_else,
+                ..
+            } => {
+                for branch in branches.iter() {
+                    if let Some((pat, _)) = &branch.is {
+                        self.collect_pattern(pat, DECLARATION_BIT);
+                    }
+                    self.collect_expr(&branch.condition);
+                    self.collect_expr(&branch.body);
+                }
+                self.collect_expr(final_else);
+            }
+            TypedExpr::RecordAccess { record, .. } => {
+                self.collect_expr(record);
+            }
+            TypedExpr::ModuleSelect { location, .. } => {
+                self.push(*location, CONSTRUCTOR, 0);
+            }
+            TypedExpr::Tuple { elems, .. } => {
+                for e in elems {
+                    self.collect_expr(e);
+                }
+            }
+            TypedExpr::Pair { fst, snd, .. } => {
+                self.collect_expr(fst);
+                self.collect_expr(snd);
+            }
+            TypedExpr::TupleIndex { tuple, .. } => {
+                self.collect_expr(tuple);
+            }
+            TypedExpr::RecordUpdate { spread, args, .. } => {
+                self.collect_expr(spread);
+                for arg in args {
+                    self.collect_expr(&arg.value);
+                }
+            }
+            TypedExpr::UnOp {
+                location, value, ..
+            } => {
+                self.push(*location, OPERATOR, 0);
+                self.collect_expr(value);
+            }
+            TypedExpr::ErrorTerm { .. } => {}
+        }
+    }
+
+    fn collect_pattern(&mut self, pattern: &TypedPattern, extra_modifiers: u32) {
+        match pattern {
+            TypedPattern::Var { location, .. } => {
+                self.push(*location, VARIABLE, extra_modifiers);
+            }
+            TypedPattern::Assign {
+                location, pattern, ..
+            } => {
+                self.push(*location, VARIABLE, extra_modifiers);
+                self.collect_pattern(pattern, extra_modifiers);
+            }
+            TypedPattern::Int { location, .. } => {
+                self.push(*location, NUMBER, 0);
+            }
+            TypedPattern::ByteArray { location, .. } => {
+                self.push(*location, STRING, 0);
+            }
+            TypedPattern::List { elements, tail, .. } => {
+                for e in elements {
+                    self.collect_pattern(e, extra_modifiers);
+                }
+                if let Some(t) = tail {
+                    self.collect_pattern(t, extra_modifiers);
+                }
+            }
+            TypedPattern::Pair { fst, snd, .. } => {
+                self.collect_pattern(fst, extra_modifiers);
+                self.collect_pattern(snd, extra_modifiers);
+            }
+            TypedPattern::Tuple { elems, .. } => {
+                for e in elems {
+                    self.collect_pattern(e, extra_modifiers);
+                }
+            }
+            TypedPattern::Constructor {
+                location,
+                arguments,
+                ..
+            } => {
+                self.push(*location, ENUM_MEMBER, 0);
+                for arg in arguments {
+                    self.collect_pattern(&arg.value, extra_modifiers);
+                }
+            }
+            TypedPattern::Discard { .. } => {}
+        }
+    }
+
+    fn collect_annotation(&mut self, ann: &aiken_lang::ast::Annotation) {
+        match ann {
+            aiken_lang::ast::Annotation::Constructor {
+                location,
+                arguments,
+                ..
+            } => {
+                self.push(*location, TYPE, 0);
+                for arg in arguments {
+                    self.collect_annotation(arg);
+                }
+            }
+            aiken_lang::ast::Annotation::Fn { arguments, ret, .. } => {
+                for arg in arguments {
+                    self.collect_annotation(arg);
+                }
+                self.collect_annotation(ret);
+            }
+            aiken_lang::ast::Annotation::Var { location, .. } => {
+                self.push(*location, TYPE, 0);
+            }
+            aiken_lang::ast::Annotation::Tuple { elems, .. } => {
+                for e in elems {
+                    self.collect_annotation(e);
+                }
+            }
+            aiken_lang::ast::Annotation::Pair { fst, snd, .. } => {
+                self.collect_annotation(fst);
+                self.collect_annotation(snd);
+            }
+            aiken_lang::ast::Annotation::Hole { .. } => {}
+        }
+    }
+}
+
+fn collect_doc_comments(collector: &mut RawCollector<'_>, extra: &ModuleExtra, source: &str) {
+    for span in &extra.doc_comments {
+        if span.end > span.start {
+            collector.push(*span, COMMENT, DOCUMENTATION_BIT);
+        }
+    }
+    for span in &extra.comments {
+        if span.end > span.start {
+            collector.push(*span, COMMENT, 0);
+        }
+    }
+    let _ = source;
+}
+
+const KEYWORDS: &[&str] = &[
+    "as",
+    "const",
+    "else",
+    "expect",
+    "fail",
+    "fn",
+    "if",
+    "is",
+    "let",
+    "opaque",
+    "pub",
+    "test",
+    "todo",
+    "trace",
+    "type",
+    "use",
+    "validator",
+    "via",
+    "when",
+    "and",
+    "or",
+    "bench",
+];
+
+fn collect_keywords(collector: &mut RawCollector<'_>, source: &str, line_numbers: &LineNumbers) {
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        while i < len && !is_ident_start(bytes[i]) {
+            i += 1;
+        }
+        if i >= len {
+            break;
+        }
+
+        let start = i;
+        while i < len && is_ident_continue(bytes[i]) {
+            i += 1;
+        }
+
+        let word = &source[start..i];
+        let word_lower = word.to_lowercase();
+
+        if KEYWORDS.contains(&word_lower.as_str()) {
+            let span = Span { start, end: i };
+            collector.push(span, KEYWORD, 0);
+        }
+    }
+
+    let _ = line_numbers;
+}
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -32,8 +32,8 @@ use lsp_types::{
     },
     request::{
         CodeActionRequest, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
-        InlayHintRequest, PrepareRenameRequest, References, Rename, Request,
-        WillSaveWaitUntil, WorkDoneProgressCreate,
+        InlayHintRequest, PrepareRenameRequest, References, Rename, Request, WillSaveWaitUntil,
+        WorkDoneProgressCreate,
     },
 };
 use miette::Diagnostic;
@@ -97,6 +97,9 @@ pub struct Server {
 
     /// Files changed since last successful compilation (used to avoid no-op compiles)
     files_changed_since_compile: HashSet<String>,
+
+    /// Timestamp of last DidChange notification for debouncing live diagnostics
+    last_change: Option<std::time::Instant>,
 }
 
 fn process_diagnostic_into<E>(
@@ -263,12 +266,17 @@ impl Server {
         let _ = self.pending_compile.take();
         if let Some(config) = self.config.clone() {
             let root = self.root.clone();
+            let edited = self.edited.clone();
             let dep_cache = self
                 .compiler
                 .as_ref()
                 .map(|c| c.dep_cache().clone())
                 .unwrap_or_default();
             let handle = std::thread::spawn(move || {
+                // Apply unsaved edits before compiling so diagnostics match
+                // the in-editor content. Files are restored after compile.
+                let _guard = EditedFileGuard::new(&edited);
+
                 let mut compiler =
                     LspProject::new_with_cache(config, root, telemetry::Lsp, dep_cache);
                 let result = compiler.compile();
@@ -300,15 +308,25 @@ impl Server {
             .as_ref()
             .map(|h| h.is_finished())
             .unwrap_or(false);
-        if finished
-            && let Some(handle) = self.pending_compile.take()
-            && let Ok(result) = handle.join()
-        {
-            self.compiler = Some(result.compiler);
-            self.files_changed_since_compile.clear();
-            self.stored_diagnostics = result.stored_diagnostics;
-            self.stored_messages = result.stored_messages;
-            self.notify_client_of_compilation_end(connection)?;
+        if finished && let Some(handle) = self.pending_compile.take() {
+            match handle.join() {
+                Ok(result) => {
+                    self.compiler = Some(result.compiler);
+                    self.files_changed_since_compile.clear();
+                    self.stored_diagnostics = result.stored_diagnostics;
+                    self.stored_messages = result.stored_messages;
+                    self.notify_client_of_compilation_end(connection)?;
+                }
+                Err(_) => {
+                    tracing::error!("Background compilation thread panicked");
+                    // Keep files_changed_since_compile so next save retries
+                    self.stored_messages.push(lsp_types::ShowMessageParams {
+                        typ: lsp_types::MessageType::ERROR,
+                        message: "Background compilation crashed — please save again to retry"
+                            .to_string(),
+                    });
+                }
+            }
             self.publish_stored_diagnostics(connection)?;
         }
         Ok(())
@@ -393,6 +411,7 @@ impl Server {
                 if let Some(changes) = params.content_changes.into_iter().next() {
                     self.edited.insert(path.clone(), changes.text);
                     self.files_changed_since_compile.insert(path);
+                    self.last_change = Some(std::time::Instant::now());
                 }
                 Ok(())
             }
@@ -533,8 +552,12 @@ impl Server {
                                 unused_imports.extend(diagnostics);
                             }
                             Some(strategy) => {
-                                let quickfixes =
-                                    quickfix::quickfix(compiler, &params.text_document, &strategy);
+                                let quickfixes = quickfix::quickfix(
+                                    compiler,
+                                    &params.text_document,
+                                    &strategy,
+                                    &self.edited,
+                                );
                                 actions.extend(quickfixes);
                             }
                         }
@@ -550,6 +573,7 @@ impl Server {
                             compiler,
                             &params.text_document,
                             &Quickfix::UnusedImports(unused_imports),
+                            &self.edited,
                         );
                         actions.extend(quickfixes);
                     }
@@ -1430,6 +1454,7 @@ impl Server {
 
         loop {
             self.poll_compile_result(&connection)?;
+            self.try_debounced_compile(&connection)?;
             match connection
                 .receiver
                 .recv_timeout(std::time::Duration::from_millis(50))
@@ -1455,6 +1480,21 @@ impl Server {
         }
     }
 
+    /// Start a compile if enough time has passed since the last DidChange.
+    /// Uses a 300ms debounce to avoid recompiling on every keystroke.
+    #[allow(clippy::result_large_err)]
+    fn try_debounced_compile(&mut self, connection: &Connection) -> Result<(), ServerError> {
+        const DEBOUNCE_MS: u64 = 300;
+        if let Some(last) = self.last_change
+            && last.elapsed() >= std::time::Duration::from_millis(DEBOUNCE_MS)
+        {
+            self.last_change = None;
+            self.notify_client_of_compilation_start(connection)?;
+            self.spawn_compile();
+        }
+        Ok(())
+    }
+
     pub fn new(
         initialize_params: InitializeParams,
         config: Option<config::ProjectConfig>,
@@ -1471,6 +1511,7 @@ impl Server {
             compiler: None,
             pending_compile: None,
             files_changed_since_compile: HashSet::new(),
+            last_change: None,
         };
 
         server.create_new_compiler();
@@ -1706,6 +1747,36 @@ fn collect_pattern_vars(
             }
         }
         _ => {}
+    }
+}
+
+/// Writes edited (unsaved) file content to disk before compilation and restores
+/// the original content after compilation (even on panic).
+struct EditedFileGuard {
+    backups: Vec<(PathBuf, String)>,
+}
+
+impl EditedFileGuard {
+    fn new(edited: &HashMap<String, String>) -> Self {
+        let mut backups = Vec::new();
+        for (file_path, content) in edited {
+            let path = PathBuf::from(file_path);
+            if let Ok(original) = fs::read_to_string(&path)
+                && &original != content
+            {
+                let _ = fs::write(&path, content);
+                backups.push((path, original));
+            }
+        }
+        EditedFileGuard { backups }
+    }
+}
+
+impl Drop for EditedFileGuard {
+    fn drop(&mut self) {
+        for (path, original) in &self.backups {
+            let _ = fs::write(path, original);
+        }
     }
 }
 

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -4,6 +4,7 @@ use crate::{
     error::Error as ServerError,
     quickfix,
     quickfix::Quickfix,
+    semantic_tokens, signature_help,
     utils::{
         COMPILING_PROGRESS_TOKEN, CREATE_COMPILING_PROGRESS_TOKEN, path_to_uri, span_to_lsp_range,
         text_edit_replace, uri_to_module_name,
@@ -25,15 +26,17 @@ use indoc::formatdoc;
 
 use lsp_server::Connection;
 use lsp_types::{
-    DocumentFormattingParams, DocumentSymbol, InitializeParams, SymbolKind, TextEdit,
+    DocumentFormattingParams, DocumentSymbol, InitializeParams, SemanticToken, SemanticTokens,
+    SemanticTokensResult, SymbolKind, TextEdit,
     notification::{
         DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument, DidSaveTextDocument,
         Notification, Progress, PublishDiagnostics, ShowMessage,
     },
     request::{
-        CodeActionRequest, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
-        InlayHintRequest, PrepareRenameRequest, References, Rename, Request, WillSaveWaitUntil,
-        WorkDoneProgressCreate,
+        CodeActionRequest, Completion, DocumentSymbolRequest, Formatting, GotoDefinition,
+        HoverRequest, InlayHintRequest, PrepareRenameRequest, References, Rename, Request,
+        SelectionRangeRequest, SemanticTokensFullRequest, SignatureHelpRequest, WillSaveWaitUntil,
+        WorkDoneProgressCreate, WorkspaceSymbolRequest,
     },
 };
 use miette::Diagnostic;
@@ -46,6 +49,7 @@ use std::{
 pub mod inlay_hints;
 pub mod lsp_project;
 pub mod telemetry;
+pub mod workspace_symbol;
 
 /// Result returned from background compilation thread
 struct BackgroundCompileResult {
@@ -646,6 +650,84 @@ impl Server {
                 })
             }
 
+            Completion::METHOD => {
+                let params = cast_request::<Completion>(request)?;
+
+                let result = self.completion(params);
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
+            WorkspaceSymbolRequest::METHOD => {
+                let params = cast_request::<WorkspaceSymbolRequest>(request)?;
+
+                let result = self.workspace_symbol(params.query);
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
+            SignatureHelpRequest::METHOD => {
+                let params = cast_request::<SignatureHelpRequest>(request)?;
+
+                let result = signature_help::signature_help(self, params);
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
+            SemanticTokensFullRequest::METHOD => {
+                let params = cast_request::<SemanticTokensFullRequest>(request)?;
+
+                let result = self
+                    .module_for_uri(&params.text_document.uri)
+                    .map(|module| {
+                        let raw = semantic_tokens::semantic_tokens_full(module);
+                        let tokens: Vec<SemanticToken> = raw
+                            .chunks_exact(5)
+                            .map(|c| SemanticToken {
+                                delta_line: c[0],
+                                delta_start: c[1],
+                                length: c[2],
+                                token_type: c[3],
+                                token_modifiers_bitset: c[4],
+                            })
+                            .collect();
+                        SemanticTokensResult::Tokens(SemanticTokens {
+                            result_id: None,
+                            data: tokens,
+                        })
+                    });
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
+            SelectionRangeRequest::METHOD => {
+                let params = cast_request::<SelectionRangeRequest>(request)?;
+
+                let result = self.selection_range(params)?;
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
             unsupported => Err(ServerError::UnsupportedLspRequest {
                 request: unsupported.to_string(),
             }),
@@ -795,7 +877,8 @@ impl Server {
 
         // Extract symbols from module definitions
         for definition in &module.ast.definitions {
-            if let Some(symbol) = self.definition_to_symbol(definition, &line_numbers) {
+            if let Some(symbol) = self.definition_to_symbol(definition, &line_numbers, &module.code)
+            {
                 symbols.push(symbol);
             }
         }
@@ -858,22 +941,61 @@ impl Server {
         Ok(Some(references))
     }
 
+    #[allow(clippy::result_large_err)]
+    fn selection_range(
+        &self,
+        params: lsp_types::SelectionRangeParams,
+    ) -> Result<Option<Vec<lsp_types::SelectionRange>>, ServerError> {
+        let module = match self.module_for_uri(&params.text_document.uri) {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+        let line_numbers = aiken_lang::line_numbers::LineNumbers::new(&module.code);
+        let source = &module.code;
+        let mut ranges = Vec::new();
+
+        for position in params.positions {
+            let byte_index =
+                line_numbers.byte_index(position.line as usize, position.character as usize);
+            if let Some(node) = module.find_node(byte_index) {
+                let range = build_selection_range(&node, &line_numbers, source);
+                ranges.push(range);
+            }
+        }
+
+        Ok(if ranges.is_empty() {
+            None
+        } else {
+            Some(ranges)
+        })
+    }
+
     /// Convert an Aiken definition to LSP DocumentSymbol
     #[allow(deprecated)]
     fn definition_to_symbol(
         &self,
         definition: &TypedDefinition,
         line_numbers: &LineNumbers,
+        source: &str,
     ) -> Option<DocumentSymbol> {
         use aiken_lang::ast::Definition;
 
-        // TODO: selection_range should ideally cover only the name identifier, not the full definition
-        // The AST currently doesn't store a separate name span
+        /// Helper to narrow a span to just the identifier name
+        fn identifier_span(source: &str, span: Span, name: &str) -> Option<Span> {
+            let text = &source[span.start..span.end];
+            let offset = text.find(name)?;
+            Some(Span {
+                start: span.start + offset,
+                end: span.start + offset + name.len(),
+            })
+        }
 
         match definition {
             Definition::Fn(function) => {
                 let range = span_to_lsp_range(function.location, line_numbers);
-                let selection_range = span_to_lsp_range(function.location, line_numbers);
+                let selection_range = identifier_span(source, function.location, &function.name)
+                    .map(|s| span_to_lsp_range(s, line_numbers))
+                    .unwrap_or_else(|| span_to_lsp_range(function.location, line_numbers));
 
                 let mut vars = Vec::new();
                 collect_let_vars(&function.body, line_numbers, &mut vars);
@@ -891,7 +1013,9 @@ impl Server {
             }
             Definition::Test(test) => {
                 let range = span_to_lsp_range(test.location, line_numbers);
-                let selection_range = span_to_lsp_range(test.location, line_numbers);
+                let selection_range = identifier_span(source, test.location, &test.name)
+                    .map(|s| span_to_lsp_range(s, line_numbers))
+                    .unwrap_or_else(|| span_to_lsp_range(test.location, line_numbers));
 
                 let mut vars = Vec::new();
                 collect_let_vars(&test.body, line_numbers, &mut vars);
@@ -909,7 +1033,9 @@ impl Server {
             }
             Definition::Benchmark(benchmark) => {
                 let range = span_to_lsp_range(benchmark.location, line_numbers);
-                let selection_range = span_to_lsp_range(benchmark.location, line_numbers);
+                let selection_range = identifier_span(source, benchmark.location, &benchmark.name)
+                    .map(|s| span_to_lsp_range(s, line_numbers))
+                    .unwrap_or_else(|| span_to_lsp_range(benchmark.location, line_numbers));
 
                 let mut vars = Vec::new();
                 collect_let_vars(&benchmark.body, line_numbers, &mut vars);
@@ -927,7 +1053,10 @@ impl Server {
             }
             Definition::TypeAlias(type_alias) => {
                 let range = span_to_lsp_range(type_alias.location, line_numbers);
-                let selection_range = span_to_lsp_range(type_alias.location, line_numbers);
+                let selection_range =
+                    identifier_span(source, type_alias.location, &type_alias.alias)
+                        .map(|s| span_to_lsp_range(s, line_numbers))
+                        .unwrap_or_else(|| span_to_lsp_range(type_alias.location, line_numbers));
 
                 Some(DocumentSymbol {
                     name: type_alias.alias.clone(),
@@ -942,14 +1071,20 @@ impl Server {
             }
             Definition::DataType(data_type) => {
                 let range = span_to_lsp_range(data_type.location, line_numbers);
-                let selection_range = span_to_lsp_range(data_type.location, line_numbers);
+                let selection_range = identifier_span(source, data_type.location, &data_type.name)
+                    .map(|s| span_to_lsp_range(s, line_numbers))
+                    .unwrap_or_else(|| span_to_lsp_range(data_type.location, line_numbers));
 
                 // Create child symbols for constructors
                 let mut children = Vec::new();
                 for constructor in &data_type.constructors {
                     let constructor_range = span_to_lsp_range(constructor.location, line_numbers);
                     let constructor_selection_range =
-                        span_to_lsp_range(constructor.location, line_numbers);
+                        identifier_span(source, constructor.location, &constructor.name)
+                            .map(|s| span_to_lsp_range(s, line_numbers))
+                            .unwrap_or_else(|| {
+                                span_to_lsp_range(constructor.location, line_numbers)
+                            });
 
                     children.push(DocumentSymbol {
                         name: constructor.name.clone(),
@@ -980,7 +1115,9 @@ impl Server {
             }
             Definition::ModuleConstant(constant) => {
                 let range = span_to_lsp_range(constant.location, line_numbers);
-                let selection_range = span_to_lsp_range(constant.location, line_numbers);
+                let selection_range = identifier_span(source, constant.location, &constant.name)
+                    .map(|s| span_to_lsp_range(s, line_numbers))
+                    .unwrap_or_else(|| span_to_lsp_range(constant.location, line_numbers));
 
                 Some(DocumentSymbol {
                     name: constant.name.clone(),
@@ -995,7 +1132,9 @@ impl Server {
             }
             Definition::Validator(validator) => {
                 let range = span_to_lsp_range(validator.location, line_numbers);
-                let selection_range = span_to_lsp_range(validator.location, line_numbers);
+                let selection_range = identifier_span(source, validator.location, &validator.name)
+                    .map(|s| span_to_lsp_range(s, line_numbers))
+                    .unwrap_or_else(|| span_to_lsp_range(validator.location, line_numbers));
 
                 Some(DocumentSymbol {
                     name: validator.name.clone(),
@@ -1876,5 +2015,70 @@ fn collect_let_vars(
             collect_let_vars(value, line_numbers, vars);
         }
         _ => {}
+    }
+}
+
+fn build_selection_range(
+    node: &Located<'_>,
+    line_numbers: &LineNumbers,
+    source: &str,
+) -> lsp_types::SelectionRange {
+    use aiken_lang::ast::Span;
+
+    fn name_span(source: &str, span: Span, name: &str) -> Option<Span> {
+        let text = &source[span.start..span.end];
+        let offset = text.find(name)?;
+        Some(Span {
+            start: span.start + offset,
+            end: span.start + offset + name.len(),
+        })
+    }
+
+    let (full_span, def_name) = match node {
+        Located::Definition(def) => {
+            use aiken_lang::ast::Definition;
+            let name = match def {
+                Definition::Fn(f) => Some(&f.name[..]),
+                Definition::DataType(dt) => Some(&dt.name[..]),
+                Definition::TypeAlias(ta) => Some(&ta.alias[..]),
+                Definition::ModuleConstant(c) => Some(&c.name[..]),
+                Definition::Validator(v) => Some(&v.name[..]),
+                Definition::Test(t) => Some(&t.name[..]),
+                Definition::Benchmark(b) => Some(&b.name[..]),
+                Definition::Use(_) => None,
+            };
+            (def.location(), name)
+        }
+        Located::Expression(expr) => {
+            use aiken_lang::expr::TypedExpr;
+            let name = match expr {
+                TypedExpr::Var { name, .. } => Some(name.as_str()),
+                _ => None,
+            };
+            (expr.location(), name)
+        }
+        Located::Pattern(pat, _) => (pat.location(), None),
+        Located::Argument(arg, _) => (arg.location(), None),
+        Located::Annotation(ann) => (ann.location(), None),
+    };
+
+    let full_range = span_to_lsp_range(full_span, line_numbers);
+
+    if let Some(name) = def_name
+        && let Some(name_span) = name_span(source, full_span, name)
+    {
+        let name_range = span_to_lsp_range(name_span, line_numbers);
+        lsp_types::SelectionRange {
+            range: name_range,
+            parent: Some(Box::new(lsp_types::SelectionRange {
+                range: full_range,
+                parent: None,
+            })),
+        }
+    } else {
+        lsp_types::SelectionRange {
+            range: full_range,
+            parent: None,
+        }
     }
 }

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -5,12 +5,12 @@ use crate::{
     quickfix,
     quickfix::Quickfix,
     utils::{
-        path_to_uri, span_to_lsp_range, text_edit_replace, uri_to_module_name,
-        COMPILING_PROGRESS_TOKEN, CREATE_COMPILING_PROGRESS_TOKEN,
+        COMPILING_PROGRESS_TOKEN, CREATE_COMPILING_PROGRESS_TOKEN, path_to_uri, span_to_lsp_range,
+        text_edit_replace, uri_to_module_name,
     },
 };
 use aiken_lang::{
-    ast::{Definition, Located, ModuleKind, Span, TypedDefinition, Use},
+    ast::{Definition, Located, ModuleKind, Span, TypedDefinition},
     error::ExtraData,
     line_numbers::LineNumbers,
     parser,
@@ -22,18 +22,19 @@ use aiken_project::{
     module::CheckedModule,
 };
 use indoc::formatdoc;
-use itertools::Itertools;
+
 use lsp_server::Connection;
 use lsp_types::{
+    DocumentFormattingParams, DocumentSymbol, InitializeParams, SymbolKind, TextEdit,
     notification::{
         DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument, DidSaveTextDocument,
         Notification, Progress, PublishDiagnostics, ShowMessage,
     },
     request::{
-        CodeActionRequest, Completion, DocumentSymbolRequest, Formatting, GotoDefinition,
-        HoverRequest, References, Request, WorkDoneProgressCreate,
+        CodeActionRequest, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
+        InlayHintRequest, PrepareRenameRequest, References, Rename, Request,
+        WorkDoneProgressCreate,
     },
-    DocumentFormattingParams, DocumentSymbol, InitializeParams, SymbolKind, TextEdit,
 };
 use miette::Diagnostic;
 use std::{
@@ -42,6 +43,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub mod inlay_hints;
 pub mod lsp_project;
 pub mod telemetry;
 
@@ -55,14 +57,14 @@ struct BackgroundCompileResult {
 unsafe impl Send for BackgroundCompileResult {}
 
 /// Target symbol info for reference searching — enables scope-aware matching
-struct SymbolTarget {
-    name: String,
+pub(crate) struct SymbolTarget {
+    pub(crate) name: String,
     /// The module where this symbol is defined (None = local variable / unknown)
-    def_module: Option<String>,
+    pub(crate) def_module: Option<String>,
     /// Byte span of the definition site — used for precise disambiguation
-    def_span: Span,
+    pub(crate) def_span: Span,
     /// Module where lookup started — needed to disambiguate local variables
-    origin_module: String,
+    pub(crate) origin_module: String,
 }
 
 pub struct Server {
@@ -89,7 +91,7 @@ pub struct Server {
     stored_messages: Vec<lsp_types::ShowMessageParams>,
 
     /// An instance of a LspProject
-    compiler: Option<LspProject>,
+    pub(crate) compiler: Option<LspProject>,
 
     pending_compile: Option<std::thread::JoinHandle<BackgroundCompileResult>>,
 
@@ -483,18 +485,6 @@ impl Server {
                 })
             }
 
-            Completion::METHOD => {
-                let params = cast_request::<Completion>(request).expect("cast Completion");
-
-                let completions = self.completion(params);
-
-                Ok(lsp_server::Response {
-                    id,
-                    error: None,
-                    result: Some(serde_json::to_value(completions)?),
-                })
-            }
-
             CodeActionRequest::METHOD => {
                 let mut actions = Vec::new();
 
@@ -564,67 +554,46 @@ impl Server {
                 })
             }
 
+            PrepareRenameRequest::METHOD => {
+                let params = cast_request::<PrepareRenameRequest>(request)?;
+
+                let result = self.prepare_rename(params);
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
+            Rename::METHOD => {
+                let params = cast_request::<Rename>(request)?;
+
+                let result = self.rename(params);
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(result)?),
+                })
+            }
+
+            InlayHintRequest::METHOD => {
+                let params = cast_request::<InlayHintRequest>(request)?;
+
+                let hints = self.inlay_hints(params);
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(hints)?),
+                })
+            }
+
             unsupported => Err(ServerError::UnsupportedLspRequest {
                 request: unsupported.to_string(),
             }),
         }
-    }
-
-    fn completion(
-        &self,
-        params: lsp_types::CompletionParams,
-    ) -> Option<Vec<lsp_types::CompletionItem>> {
-        let found = self
-            .node_at_position(&params.text_document_position)
-            .map(|(_, found)| found);
-
-        match found {
-            // TODO: test
-            None => self.completion_for_import(&[]),
-            Some(Located::Definition(Definition::Use(Use { module, .. }))) => {
-                self.completion_for_import(module)
-            }
-
-            // TODO: autocompletion for patterns
-            Some(Located::Pattern(_pattern, _value)) => None,
-
-            // TODO: autocompletion for other definitions
-            Some(Located::Definition(_expression)) => None,
-
-            // TODO: autocompletion for expressions
-            Some(Located::Expression(_expression)) => None,
-
-            // TODO: autocompletion for arguments?
-            Some(Located::Argument(_arg_name, _tipo)) => None,
-
-            // TODO: autocompletion for annotation?
-            Some(Located::Annotation(_annotation)) => None,
-        }
-    }
-
-    fn completion_for_import(&self, module: &[String]) -> Option<Vec<lsp_types::CompletionItem>> {
-        let compiler = self.compiler.as_ref()?;
-
-        // TODO: Test
-        let dependencies_modules = compiler.project.importable_modules();
-
-        // TODO: Test
-        let project_modules = compiler.modules.keys().cloned();
-
-        let modules = dependencies_modules
-            .into_iter()
-            .chain(project_modules)
-            .sorted()
-            .filter(|m| m.starts_with(&module.join("/")))
-            .map(|label| lsp_types::CompletionItem {
-                label,
-                kind: None,
-                documentation: None,
-                ..Default::default()
-            })
-            .collect();
-
-        Some(modules)
     }
 
     #[allow(clippy::result_large_err)]
@@ -657,8 +626,8 @@ impl Server {
                     None => return Ok(None),
                 };
 
-                let url = url::Url::from_file_path(&module.path)
-                    .expect("goto definition URL parse");
+                let url =
+                    url::Url::from_file_path(&module.path).expect("goto definition URL parse");
 
                 (url, &module.line_numbers)
             }
@@ -669,7 +638,7 @@ impl Server {
         Ok(Some(lsp_types::Location { uri, range }))
     }
 
-    fn node_at_position(
+    pub(crate) fn node_at_position(
         &self,
         params: &lsp_types::TextDocumentPositionParams,
     ) -> Option<(LineNumbers, Located<'_>)> {
@@ -687,7 +656,7 @@ impl Server {
         Some((line_numbers, node))
     }
 
-    fn module_for_uri(&self, uri: &url::Url) -> Option<&CheckedModule> {
+    pub(crate) fn module_for_uri(&self, uri: &url::Url) -> Option<&CheckedModule> {
         self.compiler.as_ref().and_then(|compiler| {
             let module_name = uri_to_module_name(uri, &self.root).expect("uri to module name");
             compiler.modules.get(&module_name)
@@ -810,7 +779,8 @@ impl Server {
 
         // Search through all modules for references to this symbol
         for (module_name, checked_module) in &compiler.modules {
-            if let Some(module_refs) = self.find_references_in_module(&target, checked_module, module_name)
+            if let Some(module_refs) =
+                self.find_references_in_module(&target, checked_module, module_name)
             {
                 references.extend(module_refs);
             }
@@ -990,7 +960,7 @@ impl Server {
     }
 
     /// Find the symbol target at the given position in a module
-    fn find_symbol_at_position(
+    pub(crate) fn find_symbol_at_position(
         &self,
         position: &lsp_types::Position,
         module: &CheckedModule,
@@ -1111,7 +1081,7 @@ impl Server {
     }
 
     /// Convert module name to URI
-    fn module_name_to_uri(&self, module_name: &str) -> Option<url::Url> {
+    pub(crate) fn module_name_to_uri(&self, module_name: &str) -> Option<url::Url> {
         if let Some(compiler) = &self.compiler
             && let Some(source) = compiler.sources.get(module_name)
         {
@@ -1121,7 +1091,7 @@ impl Server {
     }
 
     /// Find all references to a symbol in a module
-    fn find_references_in_module(
+    pub(crate) fn find_references_in_module(
         &self,
         target: &SymbolTarget,
         module: &CheckedModule,
@@ -1263,13 +1233,7 @@ impl Server {
                 }
             }
             aiken_lang::expr::TypedExpr::Call { fun, args, .. } => {
-                self.find_references_in_expr(
-                    target,
-                    fun,
-                    line_numbers,
-                    module_name,
-                    locations,
-                );
+                self.find_references_in_expr(target, fun, line_numbers, module_name, locations);
                 for arg in args {
                     self.find_references_in_expr(
                         target,
@@ -1282,12 +1246,24 @@ impl Server {
             }
             aiken_lang::expr::TypedExpr::Sequence { expressions, .. } => {
                 for expr in expressions {
-                    self.find_references_in_expr(target, expr, line_numbers, module_name, locations);
+                    self.find_references_in_expr(
+                        target,
+                        expr,
+                        line_numbers,
+                        module_name,
+                        locations,
+                    );
                 }
             }
             aiken_lang::expr::TypedExpr::Pipeline { expressions, .. } => {
                 for expr in expressions.iter() {
-                    self.find_references_in_expr(target, expr, line_numbers, module_name, locations);
+                    self.find_references_in_expr(
+                        target,
+                        expr,
+                        line_numbers,
+                        module_name,
+                        locations,
+                    );
                 }
             }
             aiken_lang::expr::TypedExpr::Fn { body, .. } => {
@@ -1295,11 +1271,23 @@ impl Server {
             }
             aiken_lang::expr::TypedExpr::List { elements, tail, .. } => {
                 for elem in elements {
-                    self.find_references_in_expr(target, elem, line_numbers, module_name, locations);
+                    self.find_references_in_expr(
+                        target,
+                        elem,
+                        line_numbers,
+                        module_name,
+                        locations,
+                    );
                 }
 
                 if let Some(tail) = tail {
-                    self.find_references_in_expr(target, tail, line_numbers, module_name, locations);
+                    self.find_references_in_expr(
+                        target,
+                        tail,
+                        line_numbers,
+                        module_name,
+                        locations,
+                    );
                 }
             }
             aiken_lang::expr::TypedExpr::BinOp { left, right, .. } => {
@@ -1364,7 +1352,13 @@ impl Server {
             }
             aiken_lang::expr::TypedExpr::Tuple { elems, .. } => {
                 for elem in elems {
-                    self.find_references_in_expr(target, elem, line_numbers, module_name, locations);
+                    self.find_references_in_expr(
+                        target,
+                        elem,
+                        line_numbers,
+                        module_name,
+                        locations,
+                    );
                 }
             }
             aiken_lang::expr::TypedExpr::Pair { fst, snd, .. } => {
@@ -1638,7 +1632,11 @@ fn collect_pattern_vars(
                 children: None,
             });
         }
-        Pattern::Assign { name, location, pattern } => {
+        Pattern::Assign {
+            name,
+            location,
+            pattern,
+        } => {
             let range = span_to_lsp_range(*location, line_numbers);
             #[allow(deprecated)]
             vars.push(DocumentSymbol {
@@ -1688,7 +1686,12 @@ fn collect_let_vars(
     use aiken_lang::expr::TypedExpr;
 
     match expr {
-        TypedExpr::Assignment { pattern, kind, value, .. } => {
+        TypedExpr::Assignment {
+            pattern,
+            kind,
+            value,
+            ..
+        } => {
             match kind {
                 AssignmentKind::Let { .. } | AssignmentKind::Expect { .. } => {
                     collect_pattern_vars(pattern, line_numbers, vars);
@@ -1702,7 +1705,11 @@ fn collect_let_vars(
                 collect_let_vars(e, line_numbers, vars);
             }
         }
-        TypedExpr::If { branches, final_else, .. } => {
+        TypedExpr::If {
+            branches,
+            final_else,
+            ..
+        } => {
             for branch in branches.iter() {
                 if let Some((is_pattern, _)) = &branch.is {
                     collect_pattern_vars(is_pattern, line_numbers, vars);
@@ -1711,7 +1718,9 @@ fn collect_let_vars(
             }
             collect_let_vars(final_else, line_numbers, vars);
         }
-        TypedExpr::When { subject, clauses, .. } => {
+        TypedExpr::When {
+            subject, clauses, ..
+        } => {
             collect_let_vars(subject, line_numbers, vars);
             for clause in clauses {
                 collect_let_vars(&clause.then, line_numbers, vars);

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -33,10 +33,10 @@ use lsp_types::{
         Notification, Progress, PublishDiagnostics, ShowMessage,
     },
     request::{
-        CodeActionRequest, Completion, DocumentSymbolRequest, Formatting, GotoDefinition,
-        HoverRequest, InlayHintRequest, PrepareRenameRequest, References, Rename, Request,
-        SelectionRangeRequest, SemanticTokensFullRequest, SignatureHelpRequest, WillSaveWaitUntil,
-        WorkDoneProgressCreate, WorkspaceSymbolRequest,
+        CodeActionRequest, CodeActionResolveRequest, Completion, DocumentSymbolRequest, Formatting,
+        GotoDefinition, HoverRequest, InlayHintRequest, PrepareRenameRequest, References, Rename,
+        Request, SelectionRangeRequest, SemanticTokensFullRequest, SignatureHelpRequest,
+        WillSaveWaitUntil, WorkDoneProgressCreate, WorkspaceSymbolRequest,
     },
 };
 use miette::Diagnostic;
@@ -169,14 +169,7 @@ fn process_diagnostic_into<E>(
         let lsp_diagnostic = lsp_types::Diagnostic {
             range: lsp_range,
             severity: Some(severity),
-            code: error.code().map(|c| {
-                lsp_types::NumberOrString::String(
-                    c.to_string()
-                        .trim()
-                        .replace("Warning ", "")
-                        .replace("Error ", ""),
-                )
-            }),
+            code: error.clean_code().map(lsp_types::NumberOrString::String),
             code_description: None,
             source: None,
             message,
@@ -587,6 +580,17 @@ impl Server {
                     id,
                     error: None,
                     result: Some(serde_json::to_value(actions)?),
+                })
+            }
+
+            CodeActionResolveRequest::METHOD => {
+                let action = cast_request::<CodeActionResolveRequest>(request)
+                    .expect("cast code action resolve request");
+
+                Ok(lsp_server::Response {
+                    id,
+                    error: None,
+                    result: Some(serde_json::to_value(action)?),
                 })
             }
 

--- a/crates/aiken-lsp/src/server.rs
+++ b/crates/aiken-lsp/src/server.rs
@@ -33,7 +33,7 @@ use lsp_types::{
     request::{
         CodeActionRequest, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
         InlayHintRequest, PrepareRenameRequest, References, Rename, Request,
-        WorkDoneProgressCreate,
+        WillSaveWaitUntil, WorkDoneProgressCreate,
     },
 };
 use miette::Diagnostic;
@@ -344,13 +344,7 @@ impl Server {
         }
     }
 
-    fn format(
-        &mut self,
-        params: DocumentFormattingParams,
-    ) -> Result<Vec<TextEdit>, Vec<ProjectError>> {
-        let path = params.text_document.uri.path();
-        let mut new_text = String::new();
-
+    fn format_src(&self, path: &str) -> Result<String, Vec<ProjectError>> {
         let src = match self.edited.get(path) {
             Some(src) => src.clone(),
             None => fs::read_to_string(path).map_err(|_| vec![])?,
@@ -360,8 +354,18 @@ impl Server {
             aiken_project::error::Error::from_parse_errors(errs, Path::new(path), &src)
         })?;
 
+        let mut new_text = String::new();
         aiken_lang::format::pretty(&mut new_text, module, extra, &src);
 
+        Ok(new_text)
+    }
+
+    fn format(
+        &mut self,
+        params: DocumentFormattingParams,
+    ) -> Result<Vec<TextEdit>, Vec<ProjectError>> {
+        let path = params.text_document.uri.path();
+        let new_text = self.format_src(path)?;
         Ok(vec![text_edit_replace(new_text)])
     }
 
@@ -452,6 +456,34 @@ impl Server {
 
                         self.publish_stored_diagnostics(connection)?;
 
+                        Ok(lsp_server::Response {
+                            id,
+                            error: None,
+                            result: Some(serde_json::json!(null)),
+                        })
+                    }
+                }
+            }
+
+            WillSaveWaitUntil::METHOD => {
+                let params = cast_request::<WillSaveWaitUntil>(request)?;
+
+                // Format the document before save so the saved file is clean
+                let path = params.text_document.uri.path();
+                let result = self.format_src(path);
+
+                match result {
+                    Ok(new_text) => {
+                        let edits = vec![text_edit_replace(new_text)];
+                        Ok(lsp_server::Response {
+                            id,
+                            error: None,
+                            result: Some(serde_json::to_value(Some(edits))?),
+                        })
+                    }
+                    Err(_) => {
+                        // If formatting fails (parse errors etc.), return null
+                        // so the client proceeds with save as-is
                         Ok(lsp_server::Response {
                             id,
                             error: None,

--- a/crates/aiken-lsp/src/server/inlay_hints.rs
+++ b/crates/aiken-lsp/src/server/inlay_hints.rs
@@ -1,0 +1,293 @@
+use crate::server::Server;
+use crate::utils::span_to_lsp_range;
+use aiken_lang::ast::{ArgName, Definition, Span, TypedDefinition, TypedFunction};
+use aiken_lang::expr::TypedExpr;
+use aiken_lang::line_numbers::LineNumbers;
+use aiken_lang::tipo::pretty::Printer;
+use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams};
+
+impl Server {
+    /// Implements the `textDocument/inlayHints` request.
+    /// Returns inline type annotations for unannotated let bindings,
+    /// function arguments, and return types.
+    pub fn inlay_hints(&self, params: InlayHintParams) -> Option<Vec<InlayHint>> {
+        let module = self.module_for_uri(&params.text_document.uri)?;
+        let line_numbers = LineNumbers::new(&module.code);
+
+        let range_start = line_numbers.byte_index(
+            params.range.start.line as usize,
+            params.range.start.character as usize,
+        );
+        let range_end = line_numbers.byte_index(
+            params.range.end.line as usize,
+            params.range.end.character as usize,
+        );
+
+        let mut printer = Printer::new();
+        let mut hints = Vec::new();
+
+        for definition in &module.ast.definitions {
+            let def_loc = definition.location();
+            if def_loc.start > range_end || def_loc.end <= range_start {
+                continue;
+            }
+            collect_definition_hints(definition, &line_numbers, &mut printer, &mut hints);
+        }
+
+        if hints.is_empty() { None } else { Some(hints) }
+    }
+}
+
+fn collect_definition_hints(
+    def: &TypedDefinition,
+    line_numbers: &LineNumbers,
+    printer: &mut Printer,
+    hints: &mut Vec<InlayHint>,
+) {
+    match def {
+        Definition::Fn(f) => collect_function_hints(f, line_numbers, printer, hints),
+        Definition::Validator(v) => {
+            for param in &v.params {
+                collect_arg_hint(param, line_numbers, printer, hints);
+            }
+            for handler in &v.handlers {
+                collect_function_hints(handler, line_numbers, printer, hints);
+            }
+            collect_function_hints(&v.fallback, line_numbers, printer, hints);
+        }
+        Definition::Test(f) => {
+            for arg_via in &f.arguments {
+                collect_arg_hint(&arg_via.arg, line_numbers, printer, hints);
+            }
+            if f.return_annotation.is_none() {
+                let return_type_str = printer.pretty_print(&f.return_type, 0);
+                let body_start = f.body.location().start;
+                let pos = span_to_lsp_range(
+                    Span {
+                        start: body_start,
+                        end: body_start,
+                    },
+                    line_numbers,
+                )
+                .start;
+                hints.push(make_hint(pos, format!("-> {} ", return_type_str)));
+            }
+            collect_expr_hints(&f.body, line_numbers, printer, hints);
+        }
+        Definition::Benchmark(f) => {
+            for arg_via in &f.arguments {
+                collect_arg_hint(&arg_via.arg, line_numbers, printer, hints);
+            }
+            if f.return_annotation.is_none() {
+                let return_type_str = printer.pretty_print(&f.return_type, 0);
+                let body_start = f.body.location().start;
+                let pos = span_to_lsp_range(
+                    Span {
+                        start: body_start,
+                        end: body_start,
+                    },
+                    line_numbers,
+                )
+                .start;
+                hints.push(make_hint(pos, format!("-> {} ", return_type_str)));
+            }
+            collect_expr_hints(&f.body, line_numbers, printer, hints);
+        }
+        _ => {}
+    }
+}
+
+fn collect_function_hints(
+    f: &TypedFunction,
+    line_numbers: &LineNumbers,
+    printer: &mut Printer,
+    hints: &mut Vec<InlayHint>,
+) {
+    for arg in &f.arguments {
+        collect_arg_hint(arg, line_numbers, printer, hints);
+    }
+    if f.return_annotation.is_none() {
+        let return_type_str = printer.pretty_print(&f.return_type, 0);
+        let body_start = f.body.location().start;
+        let pos = span_to_lsp_range(
+            Span {
+                start: body_start,
+                end: body_start,
+            },
+            line_numbers,
+        )
+        .start;
+        hints.push(make_hint(pos, format!("-> {} ", return_type_str)));
+    }
+    collect_expr_hints(&f.body, line_numbers, printer, hints);
+}
+
+fn collect_arg_hint(
+    arg: &aiken_lang::ast::TypedArg,
+    line_numbers: &LineNumbers,
+    printer: &mut Printer,
+    hints: &mut Vec<InlayHint>,
+) {
+    // Skip discarded arguments (e.g. _foo)
+    if matches!(arg.arg_name, ArgName::Discarded { .. }) {
+        return;
+    }
+    if arg.annotation.is_some() {
+        return;
+    }
+    let type_str = printer.pretty_print(&arg.tipo, 0);
+    let pos = span_to_lsp_range(
+        Span {
+            start: arg.arg_name.location().end,
+            end: arg.arg_name.location().end,
+        },
+        line_numbers,
+    )
+    .start;
+    hints.push(make_hint(pos, format!(": {}", type_str)));
+}
+
+fn collect_expr_hints(
+    expr: &TypedExpr,
+    line_numbers: &LineNumbers,
+    printer: &mut Printer,
+    hints: &mut Vec<InlayHint>,
+) {
+    match expr {
+        TypedExpr::Assignment {
+            pattern,
+            tipo,
+            value,
+            ..
+        } => {
+            let type_str = printer.pretty_print(tipo, 0);
+            let pattern_end = pattern.location().end;
+            let pos = span_to_lsp_range(
+                Span {
+                    start: pattern_end,
+                    end: pattern_end,
+                },
+                line_numbers,
+            )
+            .start;
+            hints.push(make_hint(pos, format!(": {}", type_str)));
+            collect_expr_hints(value, line_numbers, printer, hints);
+        }
+        TypedExpr::Sequence { expressions, .. } | TypedExpr::Pipeline { expressions, .. } => {
+            for e in expressions {
+                collect_expr_hints(e, line_numbers, printer, hints);
+            }
+        }
+        TypedExpr::Call { fun, args, .. } => {
+            collect_expr_hints(fun, line_numbers, printer, hints);
+            for arg in args {
+                collect_expr_hints(&arg.value, line_numbers, printer, hints);
+            }
+        }
+        TypedExpr::When {
+            subject, clauses, ..
+        } => {
+            collect_expr_hints(subject, line_numbers, printer, hints);
+            for clause in clauses {
+                collect_expr_hints(&clause.then, line_numbers, printer, hints);
+            }
+        }
+        TypedExpr::If {
+            branches,
+            final_else,
+            ..
+        } => {
+            for branch in branches.iter() {
+                collect_expr_hints(&branch.condition, line_numbers, printer, hints);
+                collect_expr_hints(&branch.body, line_numbers, printer, hints);
+            }
+            collect_expr_hints(final_else, line_numbers, printer, hints);
+        }
+        TypedExpr::Fn {
+            args,
+            body,
+            return_annotation,
+            ..
+        } => {
+            for arg in args {
+                collect_arg_hint(arg, line_numbers, printer, hints);
+            }
+            if return_annotation.is_none() {
+                // For anonymous functions, we can show a return type hint before the body
+                let body_start = body.location().start;
+                let return_type_str = printer.pretty_print(&expr.tipo(), 0);
+                let pos = span_to_lsp_range(
+                    Span {
+                        start: body_start,
+                        end: body_start,
+                    },
+                    line_numbers,
+                )
+                .start;
+                hints.push(make_hint(pos, format!("-> {} ", return_type_str)));
+            }
+            collect_expr_hints(body, line_numbers, printer, hints);
+        }
+        TypedExpr::Trace { then, text, .. } => {
+            collect_expr_hints(then, line_numbers, printer, hints);
+            collect_expr_hints(text, line_numbers, printer, hints);
+        }
+        TypedExpr::BinOp { left, right, .. } => {
+            collect_expr_hints(left, line_numbers, printer, hints);
+            collect_expr_hints(right, line_numbers, printer, hints);
+        }
+        TypedExpr::UnOp { value, .. } => {
+            collect_expr_hints(value, line_numbers, printer, hints);
+        }
+        TypedExpr::List { elements, tail, .. } => {
+            for e in elements {
+                collect_expr_hints(e, line_numbers, printer, hints);
+            }
+            if let Some(t) = tail {
+                collect_expr_hints(t, line_numbers, printer, hints);
+            }
+        }
+        TypedExpr::RecordAccess { record, .. } => {
+            collect_expr_hints(record, line_numbers, printer, hints);
+        }
+        TypedExpr::Tuple { elems, .. } => {
+            for e in elems {
+                collect_expr_hints(e, line_numbers, printer, hints);
+            }
+        }
+        TypedExpr::Pair { fst, snd, .. } => {
+            collect_expr_hints(fst, line_numbers, printer, hints);
+            collect_expr_hints(snd, line_numbers, printer, hints);
+        }
+        TypedExpr::TupleIndex { tuple, .. } => {
+            collect_expr_hints(tuple, line_numbers, printer, hints);
+        }
+        TypedExpr::RecordUpdate { spread, args, .. } => {
+            collect_expr_hints(spread, line_numbers, printer, hints);
+            for arg in args {
+                collect_expr_hints(&arg.value, line_numbers, printer, hints);
+            }
+        }
+        // Leaves: no sub-expressions to recurse into
+        TypedExpr::UInt { .. }
+        | TypedExpr::String { .. }
+        | TypedExpr::ByteArray { .. }
+        | TypedExpr::CurvePoint { .. }
+        | TypedExpr::Var { .. }
+        | TypedExpr::ModuleSelect { .. }
+        | TypedExpr::ErrorTerm { .. } => {}
+    }
+}
+
+fn make_hint(position: lsp_types::Position, label: String) -> InlayHint {
+    InlayHint {
+        position,
+        label: InlayHintLabel::String(label),
+        kind: Some(InlayHintKind::TYPE),
+        tooltip: None,
+        padding_left: Some(true),
+        padding_right: Some(false),
+        data: None,
+        text_edits: None,
+    }
+}

--- a/crates/aiken-lsp/src/server/lsp_project.rs
+++ b/crates/aiken-lsp/src/server/lsp_project.rs
@@ -1,11 +1,11 @@
 use aiken_lang::tipo::TypeInfo;
 use aiken_lang::{ast::Tracing, line_numbers::LineNumbers, test_framework::PropertyTest};
 use aiken_project::{
-    config::ProjectConfig, error::Error as ProjectError, module::CheckedModule,
-    telemetry::CoverageMode, Project,
+    Project, config::ProjectConfig, error::Error as ProjectError, module::CheckedModule,
+    telemetry::CoverageMode,
 };
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::{HashMap, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
     path::PathBuf,
 };
@@ -92,6 +92,10 @@ impl LspProject {
 
     pub fn dep_cache(&self) -> &LspDepCache {
         &self.dep_cache
+    }
+
+    pub fn own_package(&self) -> &str {
+        &self.own_package
     }
 
     pub fn compile(&mut self) -> Result<(), Vec<ProjectError>> {

--- a/crates/aiken-lsp/src/server/workspace_symbol.rs
+++ b/crates/aiken-lsp/src/server/workspace_symbol.rs
@@ -1,0 +1,203 @@
+use crate::server::Server;
+use crate::utils::span_to_lsp_range;
+use aiken_lang::ast::{Definition, TypedDefinition};
+use aiken_lang::line_numbers::LineNumbers;
+use lsp_types::{Location, SymbolInformation, SymbolKind, WorkspaceSymbolResponse};
+
+impl Server {
+    /// Implements the `workspace/symbol` request.
+    /// Returns all symbols across all compiled modules that match the given query.
+    /// An empty query returns all symbols.
+    pub fn workspace_symbol(&self, query: String) -> Option<WorkspaceSymbolResponse> {
+        let compiler = self.compiler.as_ref()?;
+        let mut symbols = Vec::new();
+
+        for (module_name, checked_module) in &compiler.modules {
+            let uri = self.module_name_to_uri(module_name)?;
+            let line_numbers = LineNumbers::new(&checked_module.code);
+
+            for definition in &checked_module.ast.definitions {
+                collect_definition_symbols(definition, &query, &uri, &line_numbers, &mut symbols);
+            }
+        }
+
+        if symbols.is_empty() {
+            None
+        } else {
+            Some(WorkspaceSymbolResponse::Flat(symbols))
+        }
+    }
+}
+
+/// Collect LSP SymbolInformation entries from a single typed definition.
+///
+/// Maps Aiken constructs to `SymbolKind`:
+///   - `Fn`, `Test`, `Benchmark` → `FUNCTION`
+///   - `DataType`, `TypeAlias`, `Validator` → `CLASS`
+///   - `ModuleConstant` → `CONSTANT`
+///   - Constructor records (children of DataType) → `CONSTRUCTOR`
+///   - `Use` statements → skipped
+///
+/// Filtering by query is case-insensitive substring matching.
+#[allow(deprecated)]
+fn collect_definition_symbols(
+    definition: &TypedDefinition,
+    query: &str,
+    uri: &lsp_types::Url,
+    line_numbers: &LineNumbers,
+    symbols: &mut Vec<SymbolInformation>,
+) {
+    match definition {
+        Definition::Fn(function) => {
+            if !matches_query(&function.name, query) {
+                return;
+            }
+            let range = span_to_lsp_range(function.location, line_numbers);
+            symbols.push(SymbolInformation {
+                name: function.name.clone(),
+                kind: SymbolKind::FUNCTION,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: None,
+                tags: None,
+            });
+        }
+
+        Definition::DataType(data_type) => {
+            if matches_query(&data_type.name, query) {
+                let range = span_to_lsp_range(data_type.location, line_numbers);
+                symbols.push(SymbolInformation {
+                    name: data_type.name.clone(),
+                    kind: SymbolKind::CLASS,
+                    deprecated: None,
+                    location: Location {
+                        uri: uri.clone(),
+                        range,
+                    },
+                    container_name: None,
+                    tags: None,
+                });
+            }
+
+            for constructor in &data_type.constructors {
+                if matches_query(&constructor.name, query) {
+                    let range = span_to_lsp_range(constructor.location, line_numbers);
+                    symbols.push(SymbolInformation {
+                        name: constructor.name.clone(),
+                        kind: SymbolKind::CONSTRUCTOR,
+                        deprecated: None,
+                        location: Location {
+                            uri: uri.clone(),
+                            range,
+                        },
+                        container_name: None,
+                        tags: None,
+                    });
+                }
+            }
+        }
+
+        Definition::TypeAlias(type_alias) => {
+            if !matches_query(&type_alias.alias, query) {
+                return;
+            }
+            let range = span_to_lsp_range(type_alias.location, line_numbers);
+            symbols.push(SymbolInformation {
+                name: type_alias.alias.clone(),
+                kind: SymbolKind::CLASS,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: None,
+                tags: None,
+            });
+        }
+
+        Definition::ModuleConstant(constant) => {
+            if !matches_query(&constant.name, query) {
+                return;
+            }
+            let range = span_to_lsp_range(constant.location, line_numbers);
+            symbols.push(SymbolInformation {
+                name: constant.name.clone(),
+                kind: SymbolKind::CONSTANT,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: None,
+                tags: None,
+            });
+        }
+
+        Definition::Validator(validator) => {
+            if !matches_query(&validator.name, query) {
+                return;
+            }
+            let range = span_to_lsp_range(validator.location, line_numbers);
+            symbols.push(SymbolInformation {
+                name: validator.name.clone(),
+                kind: SymbolKind::CLASS,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: None,
+                tags: None,
+            });
+        }
+
+        Definition::Test(test) => {
+            if !matches_query(&test.name, query) {
+                return;
+            }
+            let range = span_to_lsp_range(test.location, line_numbers);
+            symbols.push(SymbolInformation {
+                name: test.name.clone(),
+                kind: SymbolKind::FUNCTION,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: None,
+                tags: None,
+            });
+        }
+
+        Definition::Benchmark(benchmark) => {
+            if !matches_query(&benchmark.name, query) {
+                return;
+            }
+            let range = span_to_lsp_range(benchmark.location, line_numbers);
+            symbols.push(SymbolInformation {
+                name: benchmark.name.clone(),
+                kind: SymbolKind::FUNCTION,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range,
+                },
+                container_name: None,
+                tags: None,
+            });
+        }
+
+        Definition::Use(_) => {
+            // Skip use statements — not meaningful as workspace symbols
+        }
+    }
+}
+
+/// Case-insensitive substring match.
+/// An empty query matches everything.
+fn matches_query(name: &str, query: &str) -> bool {
+    query.is_empty() || name.to_lowercase().contains(&query.to_lowercase())
+}

--- a/crates/aiken-lsp/src/signature_help.rs
+++ b/crates/aiken-lsp/src/signature_help.rs
@@ -1,0 +1,338 @@
+use crate::server::Server;
+use aiken_lang::{
+    ast::{CallArg, Definition, Span, TypedDefinition, TypedModule, TypedPattern},
+    expr::TypedExpr,
+    line_numbers::LineNumbers,
+    tipo::{
+        ModuleValueConstructor, Type, ValueConstructor, ValueConstructorVariant, fields::FieldMap,
+        pretty::Printer,
+    },
+};
+use lsp_types::{
+    ParameterInformation, ParameterLabel, SignatureHelp, SignatureHelpParams, SignatureInformation,
+};
+use std::rc::Rc;
+
+pub fn signature_help(server: &Server, params: SignatureHelpParams) -> Option<SignatureHelp> {
+    let module = server.module_for_uri(&params.text_document_position_params.text_document.uri)?;
+    let line_numbers = LineNumbers::new(&module.code);
+    let byte_index = line_numbers.byte_index(
+        params.text_document_position_params.position.line as usize,
+        params.text_document_position_params.position.character as usize,
+    );
+
+    let (constructor, active_param) = find_enclosing_call_at(&module.ast, byte_index)?;
+
+    let signature = build_signature(&constructor, active_param)?;
+
+    Some(SignatureHelp {
+        signatures: vec![signature],
+        active_signature: Some(0),
+        active_parameter: Some(active_param as u32),
+    })
+}
+
+/// Walk module definitions for the innermost Call node whose span contains `byte_index`,
+/// returning the called function's `ValueConstructor` and the active parameter index.
+fn find_enclosing_call_at(
+    ast: &TypedModule,
+    byte_index: usize,
+) -> Option<(ValueConstructor, usize)> {
+    ast.definitions
+        .iter()
+        .find_map(|def| find_call_in_definition(def, byte_index))
+}
+
+fn find_call_in_definition(
+    definition: &TypedDefinition,
+    byte_index: usize,
+) -> Option<(ValueConstructor, usize)> {
+    match definition {
+        Definition::Fn(func) => find_call_in_expr(&func.body, byte_index),
+        Definition::Test(test) => find_call_in_expr(&test.body, byte_index),
+        Definition::Benchmark(bench) => find_call_in_expr(&bench.body, byte_index),
+        Definition::Validator(validator) => validator
+            .handlers
+            .iter()
+            .find_map(|handler| find_call_in_expr(&handler.body, byte_index))
+            .or_else(|| find_call_in_expr(&validator.fallback.body, byte_index)),
+        Definition::ModuleConstant(constant) => find_call_in_expr(&constant.value, byte_index),
+        _ => None,
+    }
+}
+
+fn find_call_in_expr(expr: &TypedExpr, byte_index: usize) -> Option<(ValueConstructor, usize)> {
+    if !expr.location().contains(byte_index) {
+        return None;
+    }
+
+    match expr {
+        TypedExpr::Call {
+            fun,
+            args,
+            location,
+            ..
+        } => {
+            for arg in args {
+                if let Some(result) = find_call_in_expr(&arg.value, byte_index) {
+                    return Some(result);
+                }
+            }
+            if let Some(result) = find_call_in_expr(fun, byte_index) {
+                return Some(result);
+            }
+
+            let constructor = match fun.as_ref() {
+                TypedExpr::Var { constructor, .. } => constructor.clone(),
+                TypedExpr::ModuleSelect {
+                    constructor, tipo, ..
+                } => match constructor {
+                    ModuleValueConstructor::Record {
+                        name,
+                        arity,
+                        tipo,
+                        field_map,
+                        location,
+                    } => ValueConstructor {
+                        public: true,
+                        variant: ValueConstructorVariant::Record {
+                            name: name.clone(),
+                            arity: *arity,
+                            field_map: field_map.clone(),
+                            location: *location,
+                            module: String::new(),
+                            constructors_count: 1,
+                        },
+                        tipo: tipo.clone(),
+                    },
+                    ModuleValueConstructor::Fn {
+                        module,
+                        name,
+                        location,
+                    } => ValueConstructor {
+                        public: true,
+                        variant: ValueConstructorVariant::ModuleFn {
+                            name: name.clone(),
+                            field_map: None,
+                            module: module.clone(),
+                            arity: 0,
+                            location: *location,
+                            builtin: None,
+                        },
+                        tipo: tipo.clone(),
+                    },
+                    _ => return None,
+                },
+                _ => return None,
+            };
+
+            let active_param = count_args_before_cursor(args, byte_index, location);
+
+            Some((constructor, active_param))
+        }
+
+        TypedExpr::Sequence { expressions, .. } | TypedExpr::Pipeline { expressions, .. } => {
+            expressions
+                .iter()
+                .find_map(|e| find_call_in_expr(e, byte_index))
+        }
+
+        TypedExpr::Fn { body, .. } => find_call_in_expr(body, byte_index),
+
+        TypedExpr::Assignment { value, pattern, .. } => {
+            find_call_in_expr_in_pattern(pattern, byte_index)
+                .or_else(|| find_call_in_expr(value, byte_index))
+        }
+
+        TypedExpr::List { elements, tail, .. } => elements
+            .iter()
+            .find_map(|e| find_call_in_expr(e, byte_index))
+            .or_else(|| tail.as_ref().and_then(|t| find_call_in_expr(t, byte_index))),
+
+        TypedExpr::BinOp { left, right, .. } => {
+            find_call_in_expr(left, byte_index).or_else(|| find_call_in_expr(right, byte_index))
+        }
+
+        TypedExpr::Trace { then, text, .. } => {
+            find_call_in_expr(then, byte_index).or_else(|| find_call_in_expr(text, byte_index))
+        }
+
+        TypedExpr::When {
+            subject, clauses, ..
+        } => find_call_in_expr(subject, byte_index).or_else(|| {
+            clauses.iter().find_map(|clause| {
+                find_call_in_expr_in_pattern(&clause.pattern, byte_index)
+                    .or_else(|| find_call_in_expr(&clause.then, byte_index))
+            })
+        }),
+
+        TypedExpr::If {
+            branches,
+            final_else,
+            ..
+        } => branches
+            .iter()
+            .find_map(|branch| {
+                find_call_in_expr(&branch.condition, byte_index)
+                    .or_else(|| find_call_in_expr(&branch.body, byte_index))
+            })
+            .or_else(|| find_call_in_expr(final_else, byte_index)),
+
+        TypedExpr::RecordAccess { record, .. } | TypedExpr::TupleIndex { tuple: record, .. } => {
+            find_call_in_expr(record, byte_index)
+        }
+
+        TypedExpr::RecordUpdate { spread, args, .. } => find_call_in_expr(spread, byte_index)
+            .or_else(|| {
+                args.iter()
+                    .find_map(|arg| find_call_in_expr(&arg.value, byte_index))
+            }),
+
+        TypedExpr::Tuple { elems, .. } => {
+            elems.iter().find_map(|e| find_call_in_expr(e, byte_index))
+        }
+
+        TypedExpr::Pair { fst, snd, .. } => {
+            find_call_in_expr(fst, byte_index).or_else(|| find_call_in_expr(snd, byte_index))
+        }
+
+        TypedExpr::UnOp { value, .. } => find_call_in_expr(value, byte_index),
+
+        TypedExpr::Var { .. }
+        | TypedExpr::UInt { .. }
+        | TypedExpr::String { .. }
+        | TypedExpr::ByteArray { .. }
+        | TypedExpr::ErrorTerm { .. }
+        | TypedExpr::CurvePoint { .. }
+        | TypedExpr::ModuleSelect { .. } => None,
+    }
+}
+
+fn find_call_in_expr_in_pattern(
+    _pattern: &TypedPattern,
+    _byte_index: usize,
+) -> Option<(ValueConstructor, usize)> {
+    None
+}
+
+fn count_args_before_cursor(
+    args: &[CallArg<TypedExpr>],
+    byte_index: usize,
+    _call_location: &Span,
+) -> usize {
+    let mut count = 0;
+    for arg in args {
+        if byte_index > arg.location.end {
+            count += 1;
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+fn build_signature(
+    constructor: &ValueConstructor,
+    active_param: usize,
+) -> Option<SignatureInformation> {
+    match &constructor.variant {
+        ValueConstructorVariant::ModuleFn {
+            name,
+            arity,
+            field_map,
+            ..
+        }
+        | ValueConstructorVariant::Record {
+            name,
+            arity,
+            field_map,
+            ..
+        } => Some(build_fn_signature(
+            name,
+            *arity,
+            field_map.as_ref(),
+            &constructor.tipo,
+            active_param,
+        )),
+
+        _ => None,
+    }
+}
+
+fn format_return_type(tipo: &Rc<Type>) -> String {
+    match tipo.as_ref() {
+        Type::Fn { ret, .. } => {
+            let mut printer = Printer::new();
+            printer.pretty_print(ret, 0)
+        }
+        _ => {
+            let mut printer = Printer::new();
+            printer.pretty_print(tipo, 0)
+        }
+    }
+}
+
+fn build_fn_signature(
+    name: &str,
+    arity: usize,
+    field_map: Option<&FieldMap>,
+    tipo: &Rc<Type>,
+    active_param: usize,
+) -> SignatureInformation {
+    let return_type = format_return_type(tipo);
+    let parameters = build_parameters(field_map, arity);
+
+    let param_string = if let Some(fm) = field_map {
+        let mut sorted: Vec<(&String, &(usize, Span))> = fm.fields.iter().collect();
+        sorted.sort_by_key(|(_, (idx, _))| *idx);
+        sorted
+            .iter()
+            .map(|(label, _)| label.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    } else if arity > 0 {
+        (0..arity)
+            .map(|i| format!("arg{}", i))
+            .collect::<Vec<_>>()
+            .join(", ")
+    } else {
+        String::new()
+    };
+
+    let label = if arity == 0 {
+        format!("type: {}", return_type)
+    } else {
+        format!("fn {}({})", name, param_string)
+    };
+
+    SignatureInformation {
+        label,
+        documentation: None,
+        parameters: Some(parameters),
+        active_parameter: Some(active_param as u32),
+    }
+}
+
+fn build_parameters(field_map: Option<&FieldMap>, arity: usize) -> Vec<ParameterInformation> {
+    if let Some(fm) = field_map {
+        let mut sorted: Vec<(&String, &(usize, Span))> = fm.fields.iter().collect();
+        sorted.sort_by_key(|(_, (idx, _))| *idx);
+
+        sorted
+            .iter()
+            .map(|(label, (_, _))| ParameterInformation {
+                label: ParameterLabel::Simple(label.to_string()),
+                documentation: None,
+            })
+            .collect()
+    } else if arity > 0 {
+        (0..arity)
+            .map(|i| ParameterInformation {
+                label: ParameterLabel::Simple(format!("arg{}", i)),
+                documentation: None,
+            })
+            .collect()
+    } else {
+        vec![]
+    }
+}

--- a/crates/aiken-lsp/src/utils.rs
+++ b/crates/aiken-lsp/src/utils.rs
@@ -39,13 +39,8 @@ pub fn text_edit_replace(new_text: String) -> TextEdit {
 
 #[allow(clippy::result_large_err)]
 pub fn path_to_uri(path: PathBuf) -> Result<lsp_types::Url, Error> {
-    let mut file: String = "file://".into();
-
-    file.push_str(&path.as_os_str().to_string_lossy());
-
-    let uri = lsp_types::Url::parse(&file)?;
-
-    Ok(uri)
+    lsp_types::Url::from_file_path(&path)
+        .map_err(|_| Error::UriError(path.to_string_lossy().to_string()))
 }
 
 pub fn span_to_lsp_range(location: Span, line_numbers: &LineNumbers) -> lsp_types::Range {

--- a/crates/aiken-project/src/error.rs
+++ b/crates/aiken-project/src/error.rs
@@ -44,7 +44,6 @@ impl fmt::Display for TomlLoadingContext {
     }
 }
 
-#[allow(dead_code)]
 #[derive(thiserror::Error)]
 pub enum Error {
     #[error("I just found two modules with the same name: '{}'", module.if_supports_color(Stderr, |s| s.yellow()))]
@@ -377,6 +376,9 @@ impl ExtraData for Error {
 pub trait GetSource {
     fn path(&self) -> Option<PathBuf>;
     fn src(&self) -> Option<String>;
+    fn clean_code(&self) -> Option<String> {
+        None
+    }
 }
 
 impl GetSource for Error {
@@ -436,6 +438,10 @@ impl GetSource for Error {
                 Some(src.to_string())
             }
         }
+    }
+
+    fn clean_code(&self) -> Option<String> {
+        self.clean_code()
     }
 }
 
@@ -682,6 +688,27 @@ impl Diagnostic for Error {
     }
 }
 
+impl Error {
+    pub fn clean_code(&self) -> Option<String> {
+        match self {
+            Error::Type { error, .. } => Some(format!(
+                "aiken::check{}",
+                error.code().map(|s| format!("::{s}")).unwrap_or_default()
+            )),
+            Error::DuplicateModule { .. } => Some("aiken::module::duplicate".into()),
+            Error::ImportCycle { .. } => Some("aiken::module::cyclical".into()),
+            Error::Parse { .. } => Some("aiken::parser".into()),
+            Error::Blueprint(e) => e.code().map(|c| c.to_string()),
+            Error::TomlLoading { .. } => Some("aiken::loading::toml".into()),
+            Error::Http(_) => Some("aiken::packages::download".into()),
+            Error::UnknownPackageVersion { .. } => Some("aiken::packages::resolve".into()),
+            Error::UnableToResolvePackage { .. } => Some("aiken::package::download".into()),
+            Error::Module(e) => e.code().map(|c| c.to_string()),
+            _ => None,
+        }
+    }
+}
+
 #[derive(thiserror::Error)]
 #[allow(clippy::large_enum_variant)]
 pub enum Warning {
@@ -743,6 +770,10 @@ impl GetSource for Warning {
             | Warning::CompilerVersionMismatch { .. }
             | Warning::SuspiciousTestMatch { .. } => None,
         }
+    }
+
+    fn clean_code(&self) -> Option<String> {
+        self.clean_code()
     }
 }
 
@@ -833,6 +864,27 @@ impl Warning {
 
     pub fn report(&self) {
         eprintln!("{self:?}")
+    }
+
+    pub fn clean_code(&self) -> Option<String> {
+        match self {
+            Warning::Type { warning, .. } => Some(format!(
+                "aiken::check{}",
+                warning.code().map(|s| format!("::{s}")).unwrap_or_default()
+            )),
+            Warning::NoValidators => Some("aiken::check".into()),
+            Warning::InvalidModuleName { .. } => Some("aiken::project::module_name".into()),
+            Warning::CompilerVersionMismatch { .. } => {
+                Some("aiken::project::compiler_version_mismatch".into())
+            }
+            Warning::DependencyAlreadyExists { .. } => {
+                Some("aiken::packages::already_exists".into())
+            }
+            Warning::NoConfigurationForEnv { .. } => {
+                Some("aiken::project::config::missing::env".into())
+            }
+            Warning::SuspiciousTestMatch { .. } => Some("aiken::check::suspicious_match".into()),
+        }
     }
 }
 

--- a/crates/aiken-project/src/lib.rs
+++ b/crates/aiken-project/src/lib.rs
@@ -54,8 +54,8 @@ use pallas_addresses::{Address, Network, ShelleyAddress, ShelleyDelegationPart, 
 use pallas_primitives::conway::PolicyId;
 use std::{
     collections::{BTreeSet, HashMap, HashSet, hash_map::DefaultHasher},
-    hash::{Hash, Hasher},
     fs::{self, File},
+    hash::{Hash, Hasher},
     io::BufReader,
     path::{Path, PathBuf},
     rc::Rc,
@@ -1002,30 +1002,32 @@ where
 
         modules.extends_glossary(&mut self.glossary);
 
-        let own_module_deps_map: HashMap<String, Vec<String>> =
-            if !self.own_module_hints.is_empty() {
-                let env_mods: Vec<String> = modules
-                    .values()
-                    .filter_map(|m| {
-                        if m.kind == ModuleKind::Env {
-                            Some(m.name.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                modules
-                    .values()
-                    .map(|m| {
-                        let (name, deps) = m.deps_for_graph(&env_mods);
-                        let own_deps: Vec<String> =
-                            deps.into_iter().filter(|d| our_modules.contains(d)).collect();
-                        (name, own_deps)
-                    })
-                    .collect()
-            } else {
-                HashMap::new()
-            };
+        let own_module_deps_map: HashMap<String, Vec<String>> = if !self.own_module_hints.is_empty()
+        {
+            let env_mods: Vec<String> = modules
+                .values()
+                .filter_map(|m| {
+                    if m.kind == ModuleKind::Env {
+                        Some(m.name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            modules
+                .values()
+                .map(|m| {
+                    let (name, deps) = m.deps_for_graph(&env_mods);
+                    let own_deps: Vec<String> = deps
+                        .into_iter()
+                        .filter(|d| our_modules.contains(d))
+                        .collect();
+                    (name, own_deps)
+                })
+                .collect()
+        } else {
+            HashMap::new()
+        };
 
         let mut cache_hit_modules: HashSet<String> = HashSet::new();
 
@@ -1035,8 +1037,7 @@ where
                     .get(&name)
                     .map(|v| v.as_slice())
                     .unwrap_or(&[]);
-                let all_deps_cache_hit =
-                    own_deps.iter().all(|d| cache_hit_modules.contains(d));
+                let all_deps_cache_hit = own_deps.iter().all(|d| cache_hit_modules.contains(d));
 
                 if all_deps_cache_hit {
                     let mut hasher = DefaultHasher::new();

--- a/crates/aiken-project/src/tests/gen_uplc.rs
+++ b/crates/aiken-project/src/tests/gen_uplc.rs
@@ -6486,10 +6486,7 @@ fn expect_non_empty_list_with_as_binding_fails_in_silent_and_verbose() {
         .apply(Term::list_data().apply(Term::var("x_id_0")))
         .apply(Term::list_data().apply(Term::var("x_id_0")))
         .lambda("x_id_0")
-        .apply(Term::empty_list().delayed_choose_list(
-            Term::Error,
-            Term::empty_list(),
-        ));
+        .apply(Term::empty_list().delayed_choose_list(Term::Error, Term::empty_list()));
 
     assert_uplc(src, program_verbose, true, true);
     assert_uplc(src, program_silent, true, false);


### PR DESCRIPTION
Implemented 7 missing LSP features, Added:
- workspace/symbol — global symbol search across modules
- textDocument/semanticTokens — AST-based semantic highlighting (12 token types)
- textDocument/completion — expanded beyond imports: expression, pattern, type annotation, and record field contexts
- textDocument/signatureHelp — function parameter info with active parameter detection
- textDocument/rename + prepareRename — workspace-wide symbol renaming with dependency guard
- textDocument/inlayHints — inline type annotations for unannotated bindings, args, and return types
- textDocument/selectionRange — nested identifier + definition range, fixed documentSymbol selection_range

New modules: completion.rs, rename.rs, semantic_tokens.rs, signature_help.rs, server/inlay_hints.rs, server/workspace_symbol.rs
Modified: lib.rs (capabilities), server.rs (routing + cleanup), lsp_project.rs (own_package accessor)